### PR TITLE
Hotfix/ftpblobstorage should append or write depending on append parameter value

### DIFF
--- a/FluentStorage.FTP/FluentFtpBlobStorage.cs
+++ b/FluentStorage.FTP/FluentFtpBlobStorage.cs
@@ -162,9 +162,16 @@ namespace FluentStorage.FTP {
 
 		public async Task WriteAsync(string fullPath, Stream dataStream,
 		   bool append = false, CancellationToken cancellationToken = default) {
+
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
 			await retryPolicy.ExecuteAsync(async () => {
+				string directory = Path.GetDirectoryName(fullPath);
+
+				if (!string.IsNullOrWhiteSpace(directory) && !(await client.DirectoryExists(directory).ConfigureAwait(false))) {
+					await client.CreateDirectory(directory, cancellationToken);
+				}
+
 				using Stream dest = append
 					? await client.OpenAppend(fullPath, FtpDataType.Binary, true, token: cancellationToken).ConfigureAwait(false)
 					: await client.OpenWrite(fullPath, FtpDataType.Binary, true, token: cancellationToken).ConfigureAwait(false);

--- a/FluentStorage.FTP/FluentFtpBlobStorage.cs
+++ b/FluentStorage.FTP/FluentFtpBlobStorage.cs
@@ -1,15 +1,18 @@
-﻿using System;
+﻿using FluentFTP;
+using FluentFTP.Exceptions;
+
+using FluentStorage.Blobs;
+
+using Polly;
+using Polly.Retry;
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using FluentFTP;
-using Polly;
-using Polly.Retry;
-using FluentStorage.Blobs;
-using FluentFTP.Exceptions;
 
 namespace FluentStorage.FTP {
 	class FluentFtpBlobStorage : IBlobStorage {
@@ -47,7 +50,7 @@ namespace FluentStorage.FTP {
 
 			FtpListItem[] items = await client.GetListing(options.FolderPath).ConfigureAwait(false);
 
-			var results = new List<Blob>();
+			List<Blob> results = new List<Blob>();
 			foreach (FtpListItem item in items) {
 				if (options.FilePrefix != null && !item.Name.StartsWith(options.FilePrefix)) {
 					continue;
@@ -76,7 +79,7 @@ namespace FluentStorage.FTP {
 			if (ff.Type != FtpObjectType.Directory && ff.Type != FtpObjectType.File)
 				return null;
 
-			var id = new Blob(ff.FullName,
+			Blob id = new Blob(ff.FullName,
 			   ff.Type == FtpObjectType.File
 			   ? BlobItemKind.File
 			   : BlobItemKind.Folder);
@@ -106,7 +109,7 @@ namespace FluentStorage.FTP {
 		public async Task<IReadOnlyCollection<bool>> ExistsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
-			var results = new List<bool>();
+			List<bool> results = new List<bool>();
 			foreach (string path in ids) {
 				bool e = await client.FileExists(path).ConfigureAwait(false);
 				results.Add(e);
@@ -118,7 +121,7 @@ namespace FluentStorage.FTP {
 		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
-			var results = new List<Blob>();
+			List<Blob> results = new List<Blob>();
 			foreach (string path in ids) {
 				string cpath = StoragePath.Normalize(path);
 				string parentPath = StoragePath.GetParent(cpath);
@@ -131,7 +134,7 @@ namespace FluentStorage.FTP {
 					continue;
 				}
 
-				var r = new Blob(path) {
+				Blob r = new Blob(path) {
 					Size = foundItem.Size,
 					LastModificationTime = foundItem.Modified
 				};
@@ -162,9 +165,15 @@ namespace FluentStorage.FTP {
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
 			await retryPolicy.ExecuteAsync(async () => {
-				using (Stream dest = await client.OpenWrite(fullPath, FtpDataType.Binary, true).ConfigureAwait(false)) {
-					await dataStream.CopyToAsync(dest).ConfigureAwait(false);
-				}
+				using Stream dest = append
+					? await client.OpenAppend(fullPath, FtpDataType.Binary, true, token: cancellationToken).ConfigureAwait(false)
+					: await client.OpenWrite(fullPath, FtpDataType.Binary, true, token: cancellationToken).ConfigureAwait(false);
+
+#if NETSTANDARD2_0
+				await dataStream.CopyToAsync(dest).ConfigureAwait(false);
+#else
+				await dataStream.CopyToAsync(dest, cancellationToken).ConfigureAwait(false);
+#endif
 			}).ConfigureAwait(false);
 		}
 

--- a/FluentStorage.Tests.FTP/FluentStorage.Tests.FTP.csproj
+++ b/FluentStorage.Tests.FTP/FluentStorage.Tests.FTP.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.analyzers" Version="1.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Testcontainers" Version="3.2.0" />
+    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FluentStorage.FTP\FluentStorage.FTP.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FluentStorage.Tests.FTP/FtpFixture.cs
+++ b/FluentStorage.Tests.FTP/FtpFixture.cs
@@ -1,0 +1,75 @@
+﻿using Bogus;
+
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+namespace FluentStorage.Tests.Integration.Ftp {
+	public class FtpFixture : IAsyncLifetime {
+
+		public IContainer FtpContainer { get; }
+
+		private static readonly Faker Faker = new();
+
+		private readonly string _userName;
+		private readonly string _password;
+
+		public string UserName => _userName;
+
+		public string Password => _userName;
+
+
+		public IEnumerable<int> GetPassivePorts() => _passivePorts;
+
+		private readonly ISet<int> _passivePorts;
+
+		private const int MaxUsersCount = 5;
+
+		private const int PassivePortStart = 15_000;
+
+		public int GetPort() => FtpContainer.GetMappedPublicPort(21);
+
+		public FtpFixture() {
+			_userName = Faker.Internet.UserName();
+			_password = Faker.Internet.Password();
+			_passivePorts = new HashSet<int>((MaxUsersCount * 2) + 1);
+
+			ContainerBuilder containerBuilder = new ContainerBuilder()
+				.WithAutoRemove(autoRemove: false)
+				.WithImage("stilliard/pure-ftpd:latest")
+				.WithEnvironment(new Dictionary<string, string> {
+					["PUBLICHOST"] = "localhost",
+					["FTP_USER_NAME"] = UserName,
+					["FTP_USER_PASS"] = Password,
+					["FTP_USER_HOME"] = $"/home/{UserName}",
+					["FTP_MAX_CLIENTS"] = $"{MaxUsersCount}",
+					["FTP_PASSIVE_PORTS"] = $"{PassivePortStart}:{(PassivePortStart + (MaxUsersCount * 2))}"
+				})
+				.WithPortBinding(21, assignRandomHostPort: true)
+				.WithTmpfsMount($"/home/{UserName}/data", AccessMode.ReadWrite)
+				.WithTmpfsMount($"/etc/pure-ftpd/passwd", AccessMode.ReadWrite)
+				;
+
+			for (int i = 0; i < MaxUsersCount; i++) {
+				int port = PassivePortStart + i;
+				containerBuilder = containerBuilder.WithPortBinding(port, assignRandomHostPort: true)
+								.WithExposedPort(port);
+			}
+
+			FtpContainer = containerBuilder.Build();
+		}
+
+		///<inheritdoc/>
+		public async Task InitializeAsync() {
+			await FtpContainer.StartAsync().ConfigureAwait(false);
+			//for (int i = 0; i < MaxUsersCount; i++) {
+			//	int containerPort = PassivePortStart + i;
+			//	_passivePorts.Add(FtpContainer.GetMappedPublicPort(containerPort));
+			//}
+
+		}
+
+		///<inheritdoc/>
+		public async Task DisposeAsync() => await FtpContainer.StopAsync().ConfigureAwait(false);
+	}
+}

--- a/FluentStorage.Tests.FTP/FtpTest.cs
+++ b/FluentStorage.Tests.FTP/FtpTest.cs
@@ -1,0 +1,57 @@
+﻿using Bogus;
+
+using FluentAssertions;
+
+using FluentFTP;
+
+using FluentStorage.Blobs;
+
+using Xunit.Abstractions;
+
+namespace FluentStorage.Tests.Integration.Ftp {
+	public class FtpTest : IClassFixture<FtpFixture>, IAsyncLifetime {
+
+		private IBlobStorage _storage;
+		private FtpFixture Fixture { get; }
+
+		private static readonly Faker Faker = new();
+		private readonly ITestOutputHelper _outputHelper;
+
+		public FtpTest(FtpFixture ftpFixture) {
+			Fixture = ftpFixture;
+			StorageFactory.Modules.UseFtpStorage();
+		}
+
+		///<inheritdoc/>
+		public async Task DisposeAsync() {
+			await Fixture.DisposeAsync();
+		}
+
+		///<inheritdoc/>
+		public async Task InitializeAsync() {
+			await Fixture.InitializeAsync();
+
+			AsyncFtpClient client = new("localhost", new System.Net.NetworkCredential(Fixture.UserName, Fixture.Password), Fixture.GetPort(), new FtpConfig { ActivePorts = Fixture.GetPassivePorts() });
+			_outputHelper?.WriteLine($"Port utilisé durant le test : {client.Port}");
+			_storage = StorageFactory.Blobs.FtpFromFluentFtpClient(client);
+		}
+
+		[Fact]
+		public async Task Given_Append_is_true_When_calling_WriteAsync_Then_the_file_should_be_uploaded_properly() {
+
+			// Arrange
+			byte[] bytesSent = Faker.Random.Bytes(1025);
+			const string fullPath = "/test/test-file.txt";
+			await _storage.OpenTransactionAsync();
+			await _storage.WriteAsync(fullPath, bytesSent.Take(1024).ToArray(), true);
+
+			// Act
+			await _storage.WriteAsync(fullPath, bytesSent.Skip(1024).ToArray(), true);
+
+			// Assert
+			byte[] received = await _storage.ReadBytesAsync(fullPath);
+			received.Should().BeEquivalentTo(bytesSent);
+
+		}
+	}
+}

--- a/FluentStorage.Tests.FTP/Usings.cs
+++ b/FluentStorage.Tests.FTP/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
+++ b/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
    <PropertyGroup>
-      <TargetFramework>net60</TargetFramework>
+      <TargetFramework>net6.0</TargetFramework>
       <LangVersion>latest</LangVersion>
    </PropertyGroup>
 
@@ -14,7 +14,10 @@
       <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
       <PackageReference Include="LogMagic" Version="2.17.5" />
       <PackageReference Include="Config.Net" Version="4.14.20" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+      <PackageReference Include="Testcontainers" Version="3.2.0" />
+      <PackageReference Include="Bogus" Version="34.0.2" />
+      <PackageReference Include="FluentAssertions" Version="6.11.0" />
+      
    </ItemGroup>
 
   <ItemGroup>
@@ -31,6 +34,10 @@
     <ProjectReference Include="..\FluentStorage.FTP\FluentStorage.FTP.csproj" />
     <ProjectReference Include="..\FluentStorage.GCP\FluentStorage.GCP.csproj" />
     <ProjectReference Include="..\FluentStorage\FluentStorage.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Blobs\" />
   </ItemGroup>
 
 </Project>

--- a/FluentStorage.Tests.Integration/Trio/BlobTest.Variations.cs
+++ b/FluentStorage.Tests.Integration/Trio/BlobTest.Variations.cs
@@ -1,6 +1,7 @@
-﻿using System.IO;
-using System.Net;
-using FluentStorage.Blobs;
+﻿using FluentStorage.Blobs;
+
+using System.IO;
+
 using Xunit;
 
 namespace FluentStorage.Tests.Integration.Blobs {
@@ -153,23 +154,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 		public AzureKeyVaultTest(AzureKeyVaultFixture fixture) : base(fixture) {
 		}
 	}
-
-	public class FtpFixture : BlobFixture {
-		protected override IBlobStorage CreateStorage(ITestSettings settings) {
-			return StorageFactory.Blobs.Ftp(
-			   settings.FtpHostName,
-			   new NetworkCredential(settings.FtpUsername, settings.FtpPassword));
-		}
-	}
-
-	/* i don't have an ftp server anymore
-	public class FtpTest : BlobTest, IClassFixture<FtpFixture>
-	{
-	   public FtpTest(FtpFixture fixture) : base(fixture)
-	   {
-
-	   }
-	}*/
 
 #if DEBUG
 	public class DatabricksFixture : BlobFixture {

--- a/FluentStorage.sln
+++ b/FluentStorage.sln
@@ -37,6 +37,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentStorage.Tests.Integra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentStorage.SFTP", "FluentStorage.SFTP\FluentStorage.SFTP.csproj", "{48D1A85B-3E34-49BC-A2E9-24FE3B5293BA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentStorage.Tests.FTP", "FluentStorage.Tests.FTP\FluentStorage.Tests.FTP.csproj", "{8EC92456-416E-40F0-8126-0D2F89ABD497}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +113,10 @@ Global
 		{48D1A85B-3E34-49BC-A2E9-24FE3B5293BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48D1A85B-3E34-49BC-A2E9-24FE3B5293BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48D1A85B-3E34-49BC-A2E9-24FE3B5293BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Fixes

Issue #23 

### Description

This PR fixes the support for the `append` parameter in the `FluentFtpBlobStorage` implementation of `IBlobStorage` which was missing.

Also the fixed implementation of `IBlobStorage.WriteAsync(string file, bool append, CancellationToken ct)` was rewritten to create the hiearchy of directory (if needed).

A new test project was added and contains only a unit/integration tests for `FluentFtpBlobStorage.WriteAsync` for now.
The new test uses [TestContainers](https://www.nuget.org/packages/Testcontainers) library to spin a FTP server during the test execution (it requires docker to be installed)