### PR TITLE
For SFTP, support for path in connection string, various bug fixes.

### DIFF
--- a/.cr/personal/FavoritesList/List.xml
+++ b/.cr/personal/FavoritesList/List.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Root Type="DevExpress.CodeRush.Foundation.CodePlaces.Options.FavoritesListContainer">
+  <Options Language="Neutral">
+    <Groups />
+  </Options>
+</Root>

--- a/.cr/personal/FavoritesList/List.xml
+++ b/.cr/personal/FavoritesList/List.xml
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Root Type="DevExpress.CodeRush.Foundation.CodePlaces.Options.FavoritesListContainer">
-  <Options Language="Neutral">
-    <Groups />
-  </Options>
-</Root>

--- a/FluentStorage.SFTP/ConnectionFactory.cs
+++ b/FluentStorage.SFTP/ConnectionFactory.cs
@@ -24,9 +24,11 @@ namespace FluentStorage.SFTP {
 				connectionString.GetRequired("host", true, out string host);
 				connectionString.GetRequired("user", true, out string user);
 				connectionString.GetRequired("password", true, out string password);
+				var path = connectionString.Get("path") ?? "";
+
 				ushort port = ushort.TryParse(connectionString.Get("port"), out port) ? port : DefaultPort;
 
-				return new SshNetSftpBlobStorage(host, port, user, password);
+				return new SshNetSftpBlobStorage(host, port, user, password, path);
 			}
 
 			return null;

--- a/FluentStorage.SFTP/Factory.cs
+++ b/FluentStorage.SFTP/Factory.cs
@@ -37,7 +37,7 @@ namespace FluentStorage {
 		/// <exception cref="T:System.ArgumentException"><paramref name="host" /> is invalid. <para>-or-</para> <paramref name="username" /> is <b>null</b> or contains only whitespace characters.</exception>
 		/// <exception cref="T:System.ArgumentOutOfRangeException"><paramref name="port" /> is not within <see cref="F:System.Net.IPEndPoint.MinPort" /> and <see cref="F:System.Net.IPEndPoint.MaxPort" />.</exception>
 		public static IBlobStorage Sftp(this IBlobStorageFactory factory, string host, int port, string username, string password)
-		   => new SshNetSftpBlobStorage(host, port, username, password);
+		   => new SshNetSftpBlobStorage(host, port, username, password, null);
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:FluentStorage.SFTP.SshNetSftpBlobStorage" /> class.


### PR DESCRIPTION
### Fixes

- Added support for a root path in the SFTP connection string.
- Various bug fixes.

### Description

1) The connection string and the `SshNetSftpBlobStorage` creator supports a `path` string, to denote the root folder that all paths will be relative too. It's similar to the `path` in the load disk provider. For example:

`sftp://host=host;path=/myfolder;user=username;password=pass`

2) Various bug fixes, for example:

- `GetBlobsAsync` should return an array with a single null if the file does not exist.
- `WriteAsync` will create the directory if it does not exist. 