### PR TITLE
Remove Newtonsoft.Json from FluentStorage project

### DIFF
--- a/FluentStorage.AWS/Messaging/AwsS3MessageReceiver.cs
+++ b/FluentStorage.AWS/Messaging/AwsS3MessageReceiver.cs
@@ -31,14 +31,14 @@ namespace FluentStorage.AWS.Messaging {
 			return attrs.ApproximateNumberOfMessages;
 		}
 
-		public override async Task ConfirmMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public override async Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			var request = new DeleteMessageBatchRequest(_queueUrl,
 			   messages.Select(m => new DeleteMessageBatchRequestEntry(m.Id, m.Properties[Converter.ReceiptHandlePropertyName])).ToList());
 
 			await _client.DeleteMessageBatchAsync(request, cancellationToken).ConfigureAwait(false);
 		}
 
-		protected override async Task<IReadOnlyCollection<QueueMessage>> ReceiveMessagesAsync(int maxBatchSize, CancellationToken cancellationToken) {
+		protected override async Task<IReadOnlyCollection<IQueueMessage>> ReceiveMessagesAsync(int maxBatchSize, CancellationToken cancellationToken) {
 			var request = new ReceiveMessageRequest(_queueUrl) {
 				MessageAttributeNames = new List<string> { ".*" },
 				MaxNumberOfMessages = Math.Min(10, maxBatchSize)
@@ -49,7 +49,7 @@ namespace FluentStorage.AWS.Messaging {
 			return messages.Messages.Select(Converter.ToQueueMessage).ToList();
 		}
 
-		public override async Task<IReadOnlyCollection<QueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) {
+		public override async Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) {
 			var request = new ReceiveMessageRequest(_queueUrl) {
 				MessageAttributeNames = new List<string> { ".*" },
 				MaxNumberOfMessages = maxMessages,
@@ -62,7 +62,7 @@ namespace FluentStorage.AWS.Messaging {
 			return messages.Messages.Select(Converter.ToQueueMessage).ToList();
 		}
 
-		public override Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
+		public override Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 	}

--- a/FluentStorage.AWS/Messaging/AwsSQSMessenger.cs
+++ b/FluentStorage.AWS/Messaging/AwsSQSMessenger.cs
@@ -81,7 +81,7 @@ namespace FluentStorage.AWS.Messaging {
 			}
 		}
 
-		public async Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 			if (messages is null)
@@ -90,7 +90,7 @@ namespace FluentStorage.AWS.Messaging {
 			string queueUri = GetQueueUri(channelName);
 
 			// SQS request size is limited
-			foreach (IEnumerable<QueueMessage> chunk in messages.Chunk(MaxEntriesPerRequest)) {
+			foreach (IEnumerable<IQueueMessage> chunk in messages.Chunk(MaxEntriesPerRequest)) {
 				var request = new SendMessageBatchRequest(
 				   queueUri,
 				   chunk.Select(Converter.ToSQSMessage).ToList());
@@ -105,15 +105,15 @@ namespace FluentStorage.AWS.Messaging {
 			}
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
 			return ReceiveInternalAsync(channelName, count, visibility ?? TimeSpan.FromMinutes(1), cancellationToken);
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			return ReceiveInternalAsync(channelName, count, TimeSpan.FromSeconds(1), cancellationToken);
 		}
 
-		private async Task<IReadOnlyCollection<QueueMessage>> ReceiveInternalAsync(
+		private async Task<IReadOnlyCollection<IQueueMessage>> ReceiveInternalAsync(
 		   string channelName, int count, TimeSpan visibility, CancellationToken cancellationToken) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
@@ -133,7 +133,7 @@ namespace FluentStorage.AWS.Messaging {
 
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 
 		#endregion

--- a/FluentStorage.AWS/Messaging/Converter.cs
+++ b/FluentStorage.AWS/Messaging/Converter.cs
@@ -8,7 +8,7 @@ namespace FluentStorage.AWS.Messaging {
 	static class Converter {
 		public const string ReceiptHandlePropertyName = "ReceiptHandle";
 
-		public static SendMessageBatchRequestEntry ToSQSMessage(QueueMessage message) {
+		public static SendMessageBatchRequestEntry ToSQSMessage(IQueueMessage message) {
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 
@@ -26,7 +26,7 @@ namespace FluentStorage.AWS.Messaging {
 			return r;
 		}
 
-		public static QueueMessage ToQueueMessage(Message sqsMessage) {
+		public static IQueueMessage ToQueueMessage(Message sqsMessage) {
 			var r = new QueueMessage(sqsMessage.Body);
 			r.Id = sqsMessage.MessageId;
 

--- a/FluentStorage.Azure.Blobs/AzureContainerBrowser.cs
+++ b/FluentStorage.Azure.Blobs/AzureContainerBrowser.cs
@@ -21,8 +21,8 @@ namespace FluentStorage.Azure.Blobs {
 			_asyncLimiter = new AsyncLimiter(maxTasks);
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> ListFolderAsync(ListOptions options, CancellationToken cancellationToken) {
-			var result = new List<Blob>();
+		public async Task<IReadOnlyCollection<IBlob>> ListFolderAsync(ListOptions options, CancellationToken cancellationToken) {
+			var result = new List<IBlob>();
 
 			await foreach (BlobHierarchyItem item in
 			   _client.GetBlobsByHierarchyAsync(
@@ -46,7 +46,7 @@ namespace FluentStorage.Azure.Blobs {
 			return result;
 		}
 
-		private static void AssumeImplicitPrefixes(string absoluteRoot, List<Blob> blobs) {
+		private static void AssumeImplicitPrefixes(string absoluteRoot, List<IBlob> blobs) {
 			absoluteRoot = StoragePath.Normalize(absoluteRoot);
 
 			List<Blob> implicitFolders = blobs

--- a/FluentStorage.Azure.Blobs/AzureDataLakeStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureDataLakeStorage.cs
@@ -45,12 +45,12 @@ namespace FluentStorage.Azure.Blobs {
 			return _extended.DeleteAsync(fullPath, cancellationToken);
 		}
 
-		public override Task<IReadOnlyCollection<Blob>> ListAsync(
+		public override Task<IReadOnlyCollection<IBlob>> ListAsync(
 		   ListOptions options, CancellationToken cancellationToken) {
 			return _extended.ListAsync(options, cancellationToken);
 		}
 
-		protected override Task<Blob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) {
+		protected override Task<IBlob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) {
 			return _extended.GetBlobAsync(fullPath, cancellationToken);
 		}
 

--- a/FluentStorage.Azure.DataLake.Store/Gen1/AzureDataLakeGen1Storage.cs
+++ b/FluentStorage.Azure.DataLake.Store/Gen1/AzureDataLakeGen1Storage.cs
@@ -58,7 +58,7 @@ namespace FluentStorage.Azure.DataLake {
 			return new AzureDataLakeGen1Storage(accountName, credential.Domain, credential.UserName, credential.Password, null);
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
+		public async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			if (options == null) options = new ListOptions();
 
 			AdlsClient client = await GetAdlsClientAsync().ConfigureAwait(false);
@@ -133,7 +133,7 @@ namespace FluentStorage.Azure.DataLake {
 			return result;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken) {
 			GenericValidation.CheckBlobFullPaths(fullPaths);
 
 			AdlsClient client = await GetAdlsClientAsync().ConfigureAwait(false);
@@ -141,11 +141,11 @@ namespace FluentStorage.Azure.DataLake {
 			return await Task.WhenAll(fullPaths.Select(fullPath => GetBlobWithMetaAsync(fullPath, client, cancellationToken))).ConfigureAwait(false);
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException("ADLS Gen1 doesn't support file metadata");
 		}
 
-		private async Task<Blob> GetBlobWithMetaAsync(string fullPath, AdlsClient client, CancellationToken cancellationToken) {
+		private async Task<IBlob> GetBlobWithMetaAsync(string fullPath, AdlsClient client, CancellationToken cancellationToken) {
 			try {
 				DirectoryEntry entry = await client.GetDirectoryEntryAsync(fullPath, cancelToken: cancellationToken).ConfigureAwait(false);
 				return new Blob(fullPath) {

--- a/FluentStorage.Azure.DataLake.Store/Gen1/DirectoryBrowser.cs
+++ b/FluentStorage.Azure.DataLake.Store/Gen1/DirectoryBrowser.cs
@@ -18,20 +18,20 @@ namespace FluentStorage.Azure.DataLake {
 			_listBatchSize = listBatchSize;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> BrowseAsync(ListOptions options, CancellationToken token) {
+		public async Task<IReadOnlyCollection<IBlob>> BrowseAsync(ListOptions options, CancellationToken token) {
 			string path = StoragePath.Normalize(options.FolderPath);
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 
 			await BrowseAsync(path, options, result, token).ConfigureAwait(false);
 
 			return result;
 		}
 
-		private async Task BrowseAsync(string path, ListOptions options, ICollection<Blob> container, CancellationToken token) {
-			List<Blob> batch;
+		private async Task BrowseAsync(string path, ListOptions options, ICollection<IBlob> container, CancellationToken token) {
+			List<IBlob> batch;
 
 			try {
-				IEnumerable<Blob> entries =
+				IEnumerable<IBlob> entries =
 				   (await EnumerateDirectoryAsync(path, options, UserGroupRepresentation.ObjectID).ConfigureAwait(false))
 				   .Where(options.IsMatch);
 
@@ -64,12 +64,12 @@ namespace FluentStorage.Azure.DataLake {
 				}
 			}
 		}
-		private async Task<IReadOnlyCollection<Blob>> EnumerateDirectoryAsync(
+		private async Task<IReadOnlyCollection<IBlob>> EnumerateDirectoryAsync(
 		   string path,
 		   ListOptions options,
 		   UserGroupRepresentation userIdFormat = UserGroupRepresentation.ObjectID,
 		   CancellationToken cancelToken = default) {
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 
 			string listAfter = "";
 

--- a/FluentStorage.Azure.EventHub/AzureEventHubMessenger.cs
+++ b/FluentStorage.Azure.EventHub/AzureEventHubMessenger.cs
@@ -83,7 +83,7 @@ namespace FluentStorage.Azure.EventHub {
 			return Task.FromResult(0L);
 		}
 
-		public async Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
@@ -96,7 +96,7 @@ namespace FluentStorage.Azure.EventHub {
 			await _client.SendAsync(messages.Select(Converter.ToEventData)).ConfigureAwait(false);
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
@@ -104,7 +104,7 @@ namespace FluentStorage.Azure.EventHub {
 			throw new NotSupportedException();
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
@@ -118,7 +118,7 @@ namespace FluentStorage.Azure.EventHub {
 			_client.Close();
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
 		public async Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) {
 			if (channelName is null)

--- a/FluentStorage.Azure.EventHub/Converter.cs
+++ b/FluentStorage.Azure.EventHub/Converter.cs
@@ -8,7 +8,7 @@ using FluentStorage.Utils.Extensions;
 
 namespace FluentStorage.Azure.EventHub {
 	static class Converter {
-		public static EventData ToEventData(QueueMessage message) {
+		public static EventData ToEventData(IQueueMessage message) {
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 
@@ -19,7 +19,7 @@ namespace FluentStorage.Azure.EventHub {
 			return ev;
 		}
 
-		public static QueueMessage ToQueueMessage(EventData ed, string partitionId) {
+		public static IQueueMessage ToQueueMessage(EventData ed, string partitionId) {
 			if (ed == null)
 				return null;
 

--- a/FluentStorage.Azure.EventHub/MessageProcessorEventProcessor.cs
+++ b/FluentStorage.Azure.EventHub/MessageProcessorEventProcessor.cs
@@ -31,7 +31,7 @@ namespace FluentStorage.Azure.EventHub {
 
 		public async Task ProcessEventsAsync(PartitionContext context, IEnumerable<EventData> messages) {
 			//forward to message processor
-			List<QueueMessage> qms = messages.Select(ed => Converter.ToQueueMessage(ed, context.PartitionId)).ToList();
+			List<IQueueMessage> qms = messages.Select(ed => Converter.ToQueueMessage(ed, context.PartitionId)).ToList();
 
 			await _messageProcessor.ProcessMessagesAsync(qms).ConfigureAwait(false);
 

--- a/FluentStorage.Azure.Files/AzureFilesBlobStorage.cs
+++ b/FluentStorage.Azure.Files/AzureFilesBlobStorage.cs
@@ -36,7 +36,7 @@ namespace FluentStorage.Azure.Files {
 			return new AzureFilesBlobStorage(account.CreateCloudFileClient());
 		}
 
-		protected override async Task<IReadOnlyCollection<Blob>> ListAtAsync(
+		protected override async Task<IReadOnlyCollection<IBlob>> ListAtAsync(
 		   string path, ListOptions options, CancellationToken cancellationToken) {
 			if (StoragePath.IsRootPath(path)) {
 				//list file shares
@@ -46,7 +46,7 @@ namespace FluentStorage.Azure.Files {
 				return shares.Results.Select(AzConvert.ToBlob).ToList();
 			}
 			else {
-				var chunk = new List<Blob>();
+				var chunk = new List<IBlob>();
 
 				CloudFileDirectory dir = await GetDirectoryReferenceAsync(path, cancellationToken).ConfigureAwait(false);
 
@@ -93,7 +93,7 @@ namespace FluentStorage.Azure.Files {
 			}
 		}
 
-		protected override async Task<Blob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) {
+		protected override async Task<IBlob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) {
 			CloudFile file = await GetFileReferenceAsync(fullPath, false, cancellationToken).ConfigureAwait(false);
 
 			try {

--- a/FluentStorage.Azure.KeyVault/Blobs/AzureKeyVaultBlobStorageProvider.cs
+++ b/FluentStorage.Azure.KeyVault/Blobs/AzureKeyVaultBlobStorageProvider.cs
@@ -26,14 +26,14 @@ namespace FluentStorage.Azure.KeyVault.Blobs {
 
 		#region [ IBlobStorage ]
 
-		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
+		public async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			if (options == null) options = new ListOptions();
 
 			GenericValidation.CheckBlobPrefix(options.FilePrefix);
 
-			if (!StoragePath.IsRootPath(options.FolderPath)) return new List<Blob>();
+			if (!StoragePath.IsRootPath(options.FolderPath)) return new List<IBlob>();
 
-			var secrets = new List<Blob>();
+			var secrets = new List<IBlob>();
 
 			await foreach (SecretProperties secretProperties in _client.GetPropertiesOfSecretsAsync(cancellationToken).ConfigureAwait(false)) {
 				Blob blob = ToBlob(secretProperties);
@@ -139,17 +139,17 @@ namespace FluentStorage.Azure.KeyVault.Blobs {
 			return true;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPaths(fullPaths);
 
 			return await Task.WhenAll(fullPaths.Select(fullPath => GetBlobAsync(fullPath))).ConfigureAwait(false);
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 
-		private async Task<Blob> GetBlobAsync(string fullPath) {
+		private async Task<IBlob> GetBlobAsync(string fullPath) {
 			fullPath = NormaliseSecretName(fullPath);
 
 			try {

--- a/FluentStorage.Azure.Messaging.ServiceBus/Converter.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Converter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using Azure.Messaging.ServiceBus;
+using FluentStorage.Messaging;
+using QueueMessage = FluentStorage.Messaging.QueueMessage;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus {
+	static class Converter {
+		public static ServiceBusMessage ToMessage(IQueueMessage message) {
+			if (message == null)
+				throw new ArgumentNullException(nameof(message));
+
+			var result = new ServiceBusMessage(message.Content);
+			if (message.Id != null) {
+				result.MessageId = message.Id;
+			}
+			if (message.Properties != null && message.Properties.Count > 0) {
+				foreach (KeyValuePair<string, string> prop in message.Properties) {
+					result.ApplicationProperties.Add(prop.Key, prop.Value);
+				}
+			}
+			return result;
+		}
+
+		public static IQueueMessage ToQueueMessage(ServiceBusReceivedMessage message) {
+			string id = message.MessageId;
+
+			var result = new QueueMessage(id, message.Body.ToArray());
+			result.DequeueCount = message.DeliveryCount;
+			if (message.ApplicationProperties != null && message.ApplicationProperties.Count > 0) {
+				foreach (KeyValuePair<string, object> pair in message.ApplicationProperties) {
+					result.Properties[pair.Key] = pair.Value?.ToString();
+				}
+			}
+
+			return result;
+		}
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
@@ -15,7 +15,7 @@ namespace FluentStorage.Azure.Messaging.ServiceBus {
 		/// </summary>
 		/// <param name="factory">Factory reference</param>
 		/// <param name="connectionString">Service Bus connection string pointing to a namespace or an entity</param>
-		public static IMessenger AzureServiceBus(this IMessagingFactory factory, string connectionString) {
+		public static IMessenger AzureMessagingServiceBus(this IMessagingFactory factory, string connectionString) {
 			return new AzureServiceBusMessenger(connectionString);
 		}
 
@@ -26,15 +26,15 @@ namespace FluentStorage.Azure.Messaging.ServiceBus {
 		/// <param name="factory">Factory reference</param>
 		/// <param name="connectionString">Service Bus connection string pointing to a namespace or an entity</param>
 		/// <param name="serviceBusOptions">Service bus clients specific options</param>
-		public static IMessenger AzureServiceBus(this IMessagingFactory factory, string connectionString,
-		                                         AzureServiceBusMessengerOptions serviceBusOptions) {
+		public static IMessenger AzureMessagingServiceBus(this IMessagingFactory factory, string connectionString,
+		                                                  AzureServiceBusMessengerOptions serviceBusOptions) {
 			return new AzureServiceBusMessenger(connectionString,serviceBusOptions);
 		}
 
 		/// <summary>
 		/// Creates Azure Service Bus Receiver for topic and subscriptions
 		/// </summary>
-		public static IMessageReceiver AzureServiceBusTopicReceiver(this IMessagingFactory factory,
+		public static IMessageReceiver AzureMessagingServiceBusTopicReceiver(this IMessagingFactory factory,
 		   string connectionString,
 		   string topicName,
 		   string subscriptionName,
@@ -46,11 +46,11 @@ namespace FluentStorage.Azure.Messaging.ServiceBus {
 		/// <summary>
 		/// Creates Azure Service Bus Receiver for queues
 		/// </summary>
-		public static IMessageReceiver AzureServiceBusQueueReceiver(this IMessagingFactory factory,
-		                                                            string connectionString,
-		                                                            string queueName,
-		                                                            ServiceBusClientOptions serviceBusClientOptions = null,
-		                                                            ServiceBusProcessorOptions messageProcessorOptions = null) {
+		public static IMessageReceiver AzureMessagingServiceBusQueueReceiver(this IMessagingFactory factory,
+		                                                                     string connectionString,
+		                                                                     string queueName,
+		                                                                     ServiceBusClientOptions serviceBusClientOptions = null,
+		                                                                     ServiceBusProcessorOptions messageProcessorOptions = null) {
 			return new AzureServiceBusQueueReceiver(connectionString, queueName, serviceBusClientOptions, messageProcessorOptions);
 		}
 

--- a/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
@@ -1,0 +1,52 @@
+﻿using Azure.Messaging.ServiceBus;
+using FluentStorage.Azure.Messaging.ServiceBus.Messenger;
+using FluentStorage.Azure.Messaging.ServiceBus.Receivers;
+using FluentStorage.Messaging;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus {
+	/// <summary>
+	/// Factory class that implement factory methods for Microsoft Azure implememtations
+	/// </summary>
+	public static class Factory {
+
+		/// <summary>
+		/// Creates a new instance of Azure Service Bus Queue by connection string and queue name.
+		/// Cast to IAzureMessagingServiceBusMessenger to access utility methods for queues, topics and subscriptions
+		/// </summary>
+		/// <param name="factory">Factory reference</param>
+		/// <param name="connectionString">Service Bus connection string pointing to a namespace or an entity</param>
+		public static IMessenger AzureServiceBus(this IMessagingFactory factory, string connectionString) {
+			return new AzureServiceBusMessenger(connectionString);
+		}
+
+		public static IMessenger AzureServiceBus(this IMessagingFactory factory, string connectionString,
+		                                         ServiceBusClientOptions clientOptions,
+		                                         AzureServiceBusMessengerOptions serviceBusOptions) {
+			return new AzureServiceBusMessenger(connectionString,serviceBusOptions);
+		}
+
+		/// <summary>
+		/// Creates Azure Service Bus Receiver for topic and subscriptions
+		/// </summary>
+		public static IMessageReceiver AzureServiceBusTopicReceiver(this IMessagingFactory factory,
+		   string connectionString,
+		   string topicName,
+		   string subscriptionName,
+		   ServiceBusClientOptions serviceBusClientOptions = null,
+		   ServiceBusProcessorOptions messageProcessorOptions = null) {
+			return new AzureServiceBusTopicReceiver(connectionString, topicName, subscriptionName, serviceBusClientOptions);
+		}
+
+		/// <summary>
+		/// Creates Azure Service Bus Receiver for queues
+		/// </summary>
+		public static IMessageReceiver AzureServiceBusQueueReceiver(this IMessagingFactory factory,
+		                                                            string connectionString,
+		                                                            string queueName,
+		                                                            ServiceBusClientOptions serviceBusClientOptions = null,
+		                                                            ServiceBusProcessorOptions messageProcessorOptions = null) {
+			return new AzureServiceBusQueueReceiver(connectionString, queueName, serviceBusClientOptions, messageProcessorOptions);
+		}
+
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Factory.cs
@@ -19,8 +19,14 @@ namespace FluentStorage.Azure.Messaging.ServiceBus {
 			return new AzureServiceBusMessenger(connectionString);
 		}
 
+		/// <summary>
+		/// Creates a new instance of Azure Service Bus Queue by connection string and queue name.
+		/// Cast to IAzureMessagingServiceBusMessenger to access utility methods for queues, topics and subscriptions
+		/// </summary>
+		/// <param name="factory">Factory reference</param>
+		/// <param name="connectionString">Service Bus connection string pointing to a namespace or an entity</param>
+		/// <param name="serviceBusOptions">Service bus clients specific options</param>
 		public static IMessenger AzureServiceBus(this IMessagingFactory factory, string connectionString,
-		                                         ServiceBusClientOptions clientOptions,
 		                                         AzureServiceBusMessengerOptions serviceBusOptions) {
 			return new AzureServiceBusMessenger(connectionString,serviceBusOptions);
 		}

--- a/FluentStorage.Azure.Messaging.ServiceBus/FluentStorage.Azure.Messaging.ServiceBus.csproj
+++ b/FluentStorage.Azure.Messaging.ServiceBus/FluentStorage.Azure.Messaging.ServiceBus.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net50;net60</TargetFrameworks>
+        <AssemblyTitle>FluentStorage.Azure.Messaging.ServiceBus</AssemblyTitle>
+        <PackageId>FluentStorage.Azure.Messaging.ServiceBus</PackageId>
+        <FileVersion>1.0.0.0</FileVersion>
+        <AssemblyVersion>1.0.0.0</AssemblyVersion>
+        <PackageLicense>https://github.com/aloneguid/storage/blob/master/LICENSE</PackageLicense>
+        <Description>Extension to FluentStorage providing Azure ServiceBus Messaging.</Description>
+        <AssemblyName>FluentStorage.Azure.Messaging.ServiceBus</AssemblyName>
+        <RootNamespace>FluentStorage.Azure.Messaging.ServiceBus</RootNamespace>
+        <Copyright>Copyright (c) 2023 Robin Rodricks and FluentStorage Contributors</Copyright>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageIcon>logo-nuget.png</PackageIcon>
+        <Authors>Robin Rodricks, Ivan Gavryliuk, FluentStorage Contributors</Authors>
+        <Version>5.2.1</Version>
+        <PackageProjectUrl>https://github.com/robinrodricks/FluentStorage</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/robinrodricks/FluentStorage</RepositoryUrl>
+        <RepositoryType>GitHub</RepositoryType>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <LangVersion>latest</LangVersion>
+        <SignAssembly>True</SignAssembly>
+        <AssemblyOriginatorKeyFile>..\FluentStorage\sn.snk</AssemblyOriginatorKeyFile>
+        <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\FluentStorage.Azure.Messaging.ServiceBus.xml</DocumentationFile>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.16.2" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\FluentStorage\FluentStorage.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="..\.github\logo-nuget.png">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+    </ItemGroup>
+
+</Project>

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusChannel.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusChannel.cs
@@ -1,0 +1,47 @@
+﻿using System;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
+
+internal class AzureServiceBusChannel {
+	internal const string TopicPrefix = "t/";
+	internal const string QueuePrefix = "q/";
+
+	internal AzureServiceBusChannel(bool isQueue, string name, string subscription) {
+		IsQueue      = isQueue;
+		Name         = name;
+		Subscription = subscription;
+	}
+
+	internal bool   IsQueue      { get; }
+	internal string Name         { get; }
+	internal string Subscription { get; }
+}
+
+internal static class AzureServiceBusChannelExtensions {
+	internal static AzureServiceBusChannel ToServiceBusChannel(this string channelName) {
+
+		if (channelName.StartsWith(AzureServiceBusChannel.QueuePrefix)) {
+			var queue = channelName.Substring(2);
+			return new AzureServiceBusChannel(true, queue, "");
+		}
+
+		if (channelName.StartsWith(AzureServiceBusChannel.TopicPrefix)) {
+			var topic   = channelName.Substring(2);
+			var arrPath = topic.Split('/');
+			if (arrPath.Length == 1)
+				return new AzureServiceBusChannel(false, topic, "");
+
+			if (arrPath.Length != 2) {
+				throw new ArgumentException(
+					$"Channel '{channelName}' is not a valid subscription name. It should start with '{AzureServiceBusChannel.TopicPrefix}' and then /<subscription name>. e.g. topicTest/subScriptionTest",
+					nameof(channelName));
+			}
+
+			return new AzureServiceBusChannel(false, arrPath[0], arrPath[1]);
+		}
+
+		throw new ArgumentException(
+			$"Channel '{channelName}' is not a valid channel name. It should start with '{AzureServiceBusChannel.QueuePrefix}' for queues, '{AzureServiceBusChannel.TopicPrefix}' for topics and subscriptions",
+			nameof(channelName));
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusChannel.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusChannel.cs
@@ -2,11 +2,11 @@
 
 namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
 
-internal class AzureServiceBusChannel {
+class AzureServiceBusChannel {
 	internal const string TopicPrefix = "t/";
 	internal const string QueuePrefix = "q/";
 
-	internal AzureServiceBusChannel(bool isQueue, string name, string subscription) {
+	public AzureServiceBusChannel(bool isQueue, string name, string subscription) {
 		IsQueue      = isQueue;
 		Name         = name;
 		Subscription = subscription;
@@ -17,8 +17,8 @@ internal class AzureServiceBusChannel {
 	internal string Subscription { get; }
 }
 
-internal static class AzureServiceBusChannelExtensions {
-	internal static AzureServiceBusChannel ToServiceBusChannel(this string channelName) {
+static class AzureServiceBusChannelExtensions {
+	public static AzureServiceBusChannel ToServiceBusChannel(this string channelName) {
 
 		if (channelName.StartsWith(AzureServiceBusChannel.QueuePrefix)) {
 			var queue = channelName.Substring(2);

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessenger.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessenger.cs
@@ -1,0 +1,279 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+using FluentStorage.Messaging;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
+	public class AzureServiceBusMessenger : IAzureMessagingServiceBusMessenger {
+
+
+		private readonly ServiceBusClient _mgmt;
+		private readonly ServiceBusAdministrationClient _mgmtAdminClient;
+		private readonly AzureServiceBusMessengerOptions _options;
+
+		private readonly ConcurrentDictionary<string, ServiceBusSender> _channelNameToMessageSender = new();
+		private readonly ConcurrentDictionary<string, ServiceBusReceiver> _channelNameToMessageReceiver = new();
+
+		internal AzureServiceBusMessenger(string connectionString) {
+			_options         = new AzureServiceBusMessengerOptions();
+			_mgmt            = new ServiceBusClient(connectionString);
+			_mgmtAdminClient = new ServiceBusAdministrationClient(connectionString);
+		}
+
+		internal AzureServiceBusMessenger(string connectionString, AzureServiceBusMessengerOptions options) {
+			_options         = options;
+			_mgmt            = new ServiceBusClient(connectionString, options.ClientOptions);
+			_mgmtAdminClient = new ServiceBusAdministrationClient(connectionString, options.AdminClientOptions);
+		}
+
+		ServiceBusSender CreateOrGetSenderClient(string channelName) =>
+			_channelNameToMessageSender.GetOrAdd(channelName,
+				_mgmt.CreateSender(channelName.ToServiceBusChannel().Name, _options.SenderOptions));
+
+		ServiceBusReceiver CreateMessageReceiver(string channelName) {
+			var channel = channelName.ToServiceBusChannel();
+
+			return channel.IsQueue || channel.Subscription == ""
+				       ? _channelNameToMessageReceiver.GetOrAdd(channelName, _mgmt.CreateReceiver(channel.Name, _options.ReceiverOptions))
+				       : _channelNameToMessageReceiver.GetOrAdd(channelName,
+					       _mgmt.CreateReceiver(channel.Name, channel.Subscription, _options.ReceiverOptions));
+		}
+
+		#region [ IMessenger ]
+
+		public async Task CreateChannelsAsync(IEnumerable<string> channelNames,
+		                                      CancellationToken cancellationToken = default) {
+			foreach (string channelName in channelNames) {
+				var channel = channelName.ToServiceBusChannel();
+
+				if (channel.IsQueue) {
+					await CreateQueueAsync(channel.Name, cancellationToken);
+				}
+				else if (!string.IsNullOrEmpty(channel.Subscription)) {
+					await CreateSubScriptionAsync(channel.Name, channel.Subscription, cancellationToken);
+				}
+				else if (!await _mgmtAdminClient.TopicExistsAsync(channel.Name, cancellationToken).ConfigureAwait(false)) {
+					await CreateTopicAsync(channel.Name, cancellationToken);
+				}
+			}
+		}
+
+		public async Task<IReadOnlyCollection<string>> ListChannelsAsync(CancellationToken cancellationToken = default) {
+			var channels = new List<string>();
+
+			var queues = _mgmtAdminClient.GetQueuesAsync(cancellationToken).ConfigureAwait(false);
+			var topics = _mgmtAdminClient.GetTopicsAsync().ConfigureAwait(false);
+
+			var subscriptionFound = false;
+
+			await foreach (var queue in queues) {
+				channels.Add($"{AzureServiceBusChannel.QueuePrefix}{queue.Name}");
+			}
+
+			await foreach (var topic in topics) {
+				var subscriptions = _mgmtAdminClient.GetSubscriptionsAsync(topic.Name).ConfigureAwait(false);
+
+				await foreach (var subscription in subscriptions) {
+					subscriptionFound = true;
+					channels.Add($"{AzureServiceBusChannel.TopicPrefix}{subscription.TopicName}/{subscription.SubscriptionName}");
+				}
+			}
+
+			if (subscriptionFound == false) {
+				await foreach (var topic in topics) {
+					channels.Add($"{AzureServiceBusChannel.TopicPrefix}{topic.Name}");
+				}
+			}
+
+			return channels;
+		}
+
+		public async Task DeleteChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) {
+			if (channelNames is null)
+				throw new ArgumentNullException(nameof(channelNames));
+
+			foreach (string channelName in channelNames) {
+				var channel = channelName.ToServiceBusChannel();
+
+				if (channel.IsQueue) {
+					await DeleteQueueAsync(channel.Name, cancellationToken);
+				}
+				else if (channel.Subscription != "") {
+					await DeleteSubScriptionAsync(channel.Name, channel.Subscription, cancellationToken);
+				}
+				else {
+					await DeleteTopicAsync(channel.Name, cancellationToken);
+				}
+			}
+		}
+
+		public async Task<long> GetMessageCountAsync(string channelName, CancellationToken cancellationToken = default) {
+			if (channelName is null)
+				throw new ArgumentNullException(nameof(channelName));
+
+			var channel = channelName.ToServiceBusChannel();
+
+			if (channel.IsQueue)
+				return await CountQueueAsync(channel.Name, cancellationToken);
+
+			if (channel.Subscription != "")
+				return await CountSubScriptionAsync(channel.Name, channel.Subscription, cancellationToken);
+
+			return await CountTopicAsync(channel.Name, cancellationToken);
+		}
+
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
+			var client       = CreateOrGetSenderClient(channelName);
+			var messageQueue = new Queue<ServiceBusMessage>();
+
+			foreach (var queueMessage in messages.Select(Converter.ToMessage)) {
+				messageQueue.Enqueue(queueMessage);
+			}
+
+			int messageCount = messageQueue.Count;
+
+			while (messageQueue.Count > 0) {
+				// start a new batch
+				using ServiceBusMessageBatch messageBatch = await client.CreateMessageBatchAsync(cancellationToken);
+
+				// add the first message to the batch
+				if (messageBatch.TryAddMessage(messageQueue.Peek())) {
+					messageQueue.Dequeue();
+				}
+				else {
+					// if the first message can't fit, then it is too large for the batch
+					throw new Exception($"Message {messageCount - messageQueue.Count} is too large and cannot be sent.");
+				}
+
+				// add as many messages as possible to the current batch
+				while (messageQueue.Count > 0 && messageBatch.TryAddMessage(messageQueue.Peek())) {
+					messageQueue.Dequeue();
+				}
+
+				await client.SendMessagesAsync(messageBatch, cancellationToken);
+			}
+		}
+
+		public async Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null,
+		                                                                   CancellationToken cancellationToken = default) {
+			if (channelName is null)
+				throw new ArgumentNullException(nameof(channelName));
+
+			var receiver = CreateMessageReceiver(channelName);
+			var messages = await receiver.ReceiveMessagesAsync(count, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+			return messages.Select(Converter.ToQueueMessage).ToList();
+		}
+
+		public async Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+			if (channelName is null)
+				throw new ArgumentNullException(nameof(channelName));
+
+			var receiver = CreateMessageReceiver(channelName);
+			var messages = await receiver.PeekMessagesAsync(count, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+			return messages.Select(Converter.ToQueueMessage).ToList();
+		}
+
+		/// <exception cref="NotImplementedException"></exception>
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages,
+		                        CancellationToken cancellationToken = default) => throw new NotImplementedException();
+
+		/// <exception cref="NotImplementedException"></exception>
+		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) =>
+			throw new NotImplementedException();
+
+		/// <summary>
+		/// Disposes all the message senders and receivers associated with this object.
+		/// </summary>
+		public void Dispose() {
+			foreach (var sender in _channelNameToMessageSender) {
+				TaskUtils.RunSync(() => sender.Value.CloseAsync());
+			}
+
+			foreach (var receiver in _channelNameToMessageReceiver) {
+				TaskUtils.RunSync(() => receiver.Value.CloseAsync());
+			}
+
+			_mgmt.DisposeAsync();
+		}
+
+		#endregion
+
+		#region [ IAzureServiceBusMessenger ]
+
+		public async Task SendToQueueAsync(string queue, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
+			var channel = $"{AzureServiceBusChannel.QueuePrefix}{queue}";
+			await SendAsync(channel, messages, cancellationToken);
+		}
+
+		public async Task SendToTopicAsync(string topic, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
+			var channel = $"{AzureServiceBusChannel.TopicPrefix}{topic}";
+			await SendAsync(channel, messages, cancellationToken);
+		}
+		public async Task SendToSubscriptionAsync(string topic, string subscription, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
+			var channel = $"{AzureServiceBusChannel.TopicPrefix}{topic}/{subscription}";
+			await SendAsync(channel, messages, cancellationToken);
+		}
+		public async Task CreateQueueAsync(string queue, CancellationToken cancellationToken = default) {
+			if (!await _mgmtAdminClient.QueueExistsAsync(queue, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.CreateQueueAsync(queue, cancellationToken);
+		}
+
+		public async Task CreateTopicAsync(string topic,CancellationToken cancellationToken = default) {
+			if ( !await _mgmtAdminClient.TopicExistsAsync(topic, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.CreateTopicAsync(topic, cancellationToken);
+		}
+
+		public async Task CreateSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default) {
+			if ( !await _mgmtAdminClient.SubscriptionExistsAsync(topic, subscription, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.CreateSubscriptionAsync(topic, subscription, cancellationToken);
+		}
+
+		public async Task DeleteQueueAsync(string queue, CancellationToken cancellationToken = default) {
+			if (!await _mgmtAdminClient.QueueExistsAsync(queue, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.DeleteQueueAsync(queue, cancellationToken);
+		}
+
+		public async Task DeleteSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default) {
+			if ( !await _mgmtAdminClient.SubscriptionExistsAsync(topic, subscription, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.DeleteSubscriptionAsync(topic, subscription, cancellationToken);
+		}
+
+		public async Task DeleteTopicAsync(string topic,CancellationToken cancellationToken = default) {
+			if ( !await _mgmtAdminClient.TopicExistsAsync(topic, cancellationToken).ConfigureAwait(false))
+				await _mgmtAdminClient.DeleteTopicAsync(topic, cancellationToken);
+		}
+
+		public async Task<long> CountQueueAsync(string queue, CancellationToken cancellationToken = default) {
+			if (!await _mgmtAdminClient.QueueExistsAsync(queue, cancellationToken).ConfigureAwait(false)) {
+				var qinfo = await _mgmtAdminClient.GetQueueRuntimePropertiesAsync(queue, cancellationToken);
+				return qinfo.HasValue ? qinfo.Value.TotalMessageCount : 0;
+			}
+			return 0;
+		}
+
+		public async Task<long> CountSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default) {
+			if (await _mgmtAdminClient.SubscriptionExistsAsync(topic, subscription, cancellationToken).ConfigureAwait(false)) {
+				var topicInfo = await _mgmtAdminClient.GetSubscriptionRuntimePropertiesAsync(topic, subscription, cancellationToken);
+				return topicInfo.HasValue ? topicInfo.Value.TotalMessageCount : 0;
+			}
+			return 0;
+		}
+
+		public async Task<long> CountTopicAsync(string topic,CancellationToken cancellationToken = default) {
+			if (await _mgmtAdminClient.TopicExistsAsync(topic, cancellationToken).ConfigureAwait(false)) {
+				var topicInfo = await _mgmtAdminClient.GetTopicRuntimePropertiesAsync(topic, cancellationToken);
+				return topicInfo.HasValue ? topicInfo.Value.ScheduledMessageCount : 0;
+			}
+			return 0;
+		}
+
+		#endregion
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessenger.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessenger.cs
@@ -9,8 +9,10 @@ using Azure.Messaging.ServiceBus.Administration;
 using FluentStorage.Messaging;
 
 namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
+	/// <summary>
+	/// Messenger service for Azure ServiceBus, cast to IAzureMessagingServiceBusMessenger to access utility methods for queues, topics and subscriptions
+	/// </summary>
 	public class AzureServiceBusMessenger : IAzureMessagingServiceBusMessenger {
-
 
 		private readonly ServiceBusClient _mgmt;
 		private readonly ServiceBusAdministrationClient _mgmtAdminClient;
@@ -188,9 +190,6 @@ namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) =>
 			throw new NotImplementedException();
 
-		/// <summary>
-		/// Disposes all the message senders and receivers associated with this object.
-		/// </summary>
 		public void Dispose() {
 			foreach (var sender in _channelNameToMessageSender) {
 				TaskUtils.RunSync(() => sender.Value.CloseAsync());

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessengerOptions.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessengerOptions.cs
@@ -1,0 +1,11 @@
+﻿using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
+
+public class AzureServiceBusMessengerOptions {
+	public ServiceBusClientOptions               ClientOptions      { get; set; } = new();
+	public ServiceBusAdministrationClientOptions AdminClientOptions { get; set; } = new();
+	public ServiceBusSenderOptions               SenderOptions      { get; set; } = new();
+	public ServiceBusReceiverOptions             ReceiverOptions    { get; set; } = new();
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessengerOptions.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/AzureServiceBusMessengerOptions.cs
@@ -3,9 +3,27 @@ using Azure.Messaging.ServiceBus.Administration;
 
 namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
 
+/// <summary>
+/// Represents the options for configuring the Azure Service Bus messenger.
+/// </summary>
 public class AzureServiceBusMessengerOptions {
-	public ServiceBusClientOptions               ClientOptions      { get; set; } = new();
+	/// <summary>
+	/// Gets or sets the options for configuring the Service Bus client.
+	/// </summary>
+	public ServiceBusClientOptions ClientOptions { get; set; } = new();
+
+	/// <summary>
+	/// Gets or sets the options for configuring the Service Bus administration client.
+	/// </summary>
 	public ServiceBusAdministrationClientOptions AdminClientOptions { get; set; } = new();
-	public ServiceBusSenderOptions               SenderOptions      { get; set; } = new();
-	public ServiceBusReceiverOptions             ReceiverOptions    { get; set; } = new();
+
+	/// <summary>
+	/// Gets or sets the options for configuring the Service Bus sender.
+	/// </summary>
+	public ServiceBusSenderOptions SenderOptions { get; set; } = new();
+
+	/// <summary>
+	/// Gets or sets the options for configuring the Service Bus receiver.
+	/// </summary>
+	public ServiceBusReceiverOptions ReceiverOptions { get; set; } = new();
 }

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/IAzureMessagingServiceBusMessenger.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/IAzureMessagingServiceBusMessenger.cs
@@ -1,0 +1,60 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentStorage.Messaging;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
+	/// <summary>
+	/// Azure Service Bus specific information
+	/// </summary>
+	public interface IAzureMessagingServiceBusMessenger : IMessenger {
+		public Task SendToQueueAsync(string queue, IEnumerable<IQueueMessage> messages,
+		                             CancellationToken cancellationToken = default);
+
+		public Task SendToTopicAsync(string topic, IEnumerable<IQueueMessage> messages,
+		                             CancellationToken cancellationToken = default);
+
+		public Task SendToSubscriptionAsync(string topic, string subscription,
+		                                    IEnumerable<IQueueMessage> messages,
+		                                    CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Create a new Queue in Azure ServiceBus
+		/// </summary>
+		/// <param name="name">Queue name</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns></returns>
+		Task CreateQueueAsync(string name, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Create a new Topic in Azure ServiceBus
+		/// </summary>
+		/// <param name="topic">Topic name</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns></returns>
+		Task CreateTopicAsync(string topic, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Create a new Subscription in Azure ServiceBus
+		/// </summary>
+		/// <param name="topic">Topic name</param>
+		/// <param name="subscription">Subscription name</param>
+		/// <param name="cancellationToken">Cancellation token</param>
+		/// <returns></returns>
+		Task CreateSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default);
+
+		public Task DeleteQueueAsync(string queue, CancellationToken cancellationToken = default);
+
+		public Task DeleteSubScriptionAsync(string topic, string subscription,
+		                                    CancellationToken cancellationToken = default);
+
+		public Task DeleteTopicAsync(string topic, CancellationToken cancellationToken = default);
+
+		public Task<long> CountQueueAsync(string queue, CancellationToken cancellationToken = default);
+
+		public Task<long> CountSubScriptionAsync(string topic, string subscription,
+		                                         CancellationToken cancellationToken = default);
+
+		public Task<long> CountTopicAsync(string topic, CancellationToken cancellationToken = default);
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/IAzureMessagingServiceBusMessenger.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/IAzureMessagingServiceBusMessenger.cs
@@ -5,18 +5,37 @@ using FluentStorage.Messaging;
 
 namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
 	/// <summary>
-	/// Azure Service Bus specific information
+	/// Provides specific messaging capabilities to Azure Service Bus IMessenger.
 	/// </summary>
 	public interface IAzureMessagingServiceBusMessenger : IMessenger {
-		public Task SendToQueueAsync(string queue, IEnumerable<IQueueMessage> messages,
-		                             CancellationToken cancellationToken = default);
 
-		public Task SendToTopicAsync(string topic, IEnumerable<IQueueMessage> messages,
-		                             CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Sends a collection of messages to the specified queue asynchronously.
+		/// </summary>
+		/// <param name="queue">The name of the queue.</param>
+		/// <param name="messages">The collection of messages to send.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task SendToQueueAsync(string queue, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default);
 
-		public Task SendToSubscriptionAsync(string topic, string subscription,
-		                                    IEnumerable<IQueueMessage> messages,
-		                                    CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Sends a collection of messages to the specified topic asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="messages">The collection of messages to send.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task SendToTopicAsync(string topic, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default);
+
+		/// <summary>
+		/// Sends a collection of messages to the specified topic subscription asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="subscription">The name of the subscription.</param>
+		/// <param name="messages">The collection of messages to send.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task SendToSubscriptionAsync(string topic, string subscription, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Create a new Queue in Azure ServiceBus
@@ -43,18 +62,54 @@ namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger {
 		/// <returns></returns>
 		Task CreateSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default);
 
-		public Task DeleteQueueAsync(string queue, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Deletes the specified queue asynchronously.
+		/// </summary>
+		/// <param name="queue">The name of the queue.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task DeleteQueueAsync(string queue, CancellationToken cancellationToken = default);
 
-		public Task DeleteSubScriptionAsync(string topic, string subscription,
-		                                    CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Deletes the specified topic subscription asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="subscription">The name of the subscription.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task DeleteSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default);
 
-		public Task DeleteTopicAsync(string topic, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Deletes the specified topic asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		Task DeleteTopicAsync(string topic, CancellationToken cancellationToken = default);
 
-		public Task<long> CountQueueAsync(string queue, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Counts the number of messages in the specified queue asynchronously.
+		/// </summary>
+		/// <param name="queue">The name of the queue.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The number of messages in the queue.</returns>
+		Task<long> CountQueueAsync(string queue, CancellationToken cancellationToken = default);
 
-		public Task<long> CountSubScriptionAsync(string topic, string subscription,
-		                                         CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Counts the number of messages in the specified topic subscription asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="subscription">The name of the subscription.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The number of messages in the topic subscription.</returns>
+		Task<long> CountSubScriptionAsync(string topic, string subscription, CancellationToken cancellationToken = default);
 
-		public Task<long> CountTopicAsync(string topic, CancellationToken cancellationToken = default);
+		/// <summary>
+		/// Counts the number of messages in the specified topic asynchronously.
+		/// </summary>
+		/// <param name="topic">The name of the topic.</param>
+		/// <param name="cancellationToken">The cancellation token.</param>
+		/// <returns>The number of messages in the topic.</returns>
+		Task<long> CountTopicAsync(string topic, CancellationToken cancellationToken = default);
 	}
 }

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/TaskUtils.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/TaskUtils.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
+
+internal class TaskUtils {
+	private static readonly TaskFactory _myTaskFactory = new
+		TaskFactory(CancellationToken.None,
+			TaskCreationOptions.None,
+			TaskContinuationOptions.None,
+			TaskScheduler.Default);
+
+	internal static void RunSync(Func<Task> func) {
+		_myTaskFactory
+			.StartNew(func)
+			.Unwrap()
+			.GetAwaiter()
+			.GetResult();
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Messenger/TaskUtils.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Messenger/TaskUtils.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace FluentStorage.Azure.Messaging.ServiceBus.Messenger;
 
-internal class TaskUtils {
+static class TaskUtils {
 	private static readonly TaskFactory _myTaskFactory = new
 		TaskFactory(CancellationToken.None,
 			TaskCreationOptions.None,

--- a/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusQueueReceiver.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusQueueReceiver.cs
@@ -1,0 +1,14 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Receivers {
+	/// <summary>
+	/// Implements message receiver on Azure Service Bus Queues
+	/// </summary>
+	internal class AzureServiceBusQueueReceiver : AzureServiceBusReceiver {
+		internal AzureServiceBusQueueReceiver(string connectionString, string queueName,
+		                                       ServiceBusClientOptions clientOptions = null,
+		                                       ServiceBusProcessorOptions processorOptions = null)
+			: base(connectionString, queueName, "", "", clientOptions, processorOptions) {
+		}
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusReceiver.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusReceiver.cs
@@ -21,12 +21,12 @@ namespace FluentStorage.Azure.Messaging.ServiceBus.Receivers {
 		private readonly ServiceBusClient _mgmt;
 		private Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> _onMessage;
 
-		public AzureServiceBusReceiver(string connectionstring,
-		                               string queueName,
-		                               string topicName,
-		                               string subscriptionName,
-		                               ServiceBusClientOptions clientOptions,
-		                               ServiceBusProcessorOptions processorOptions) {
+		protected AzureServiceBusReceiver(string connectionstring,
+		                                  string queueName,
+		                                  string topicName,
+		                                  string subscriptionName,
+		                                  ServiceBusClientOptions clientOptions,
+		                                  ServiceBusProcessorOptions processorOptions) {
 			_queueName        = queueName;
 			_topicName        = topicName;
 			_subscriptionName = subscriptionName;

--- a/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusReceiver.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusReceiver.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using FluentStorage.Messaging;
+using IMessageReceiver = FluentStorage.Messaging.IMessageReceiver;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Receivers {
+	internal abstract class AzureServiceBusReceiver : IMessageReceiver {
+		private readonly string _queueName;
+		private readonly string _topicName;
+		private readonly string _subscriptionName;
+
+		private readonly ConcurrentDictionary<string, ServiceBusReceivedMessage> _messageIdToBrokeredMessage = new();
+		private readonly ServiceBusReceiver _receiverClient;
+		private readonly ServiceBusProcessorOptions _messageHandlerOptions;
+		private readonly bool _autoComplete;
+		private readonly ServiceBusClient _mgmt;
+		private Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> _onMessage;
+
+		public AzureServiceBusReceiver(string connectionstring,
+		                               string queueName,
+		                               string topicName,
+		                               string subscriptionName,
+		                               ServiceBusClientOptions clientOptions,
+		                               ServiceBusProcessorOptions processorOptions) {
+			_queueName        = queueName;
+			_topicName        = topicName;
+			_subscriptionName = subscriptionName;
+
+			clientOptions ??= new ServiceBusClientOptions();
+
+			_mgmt = new ServiceBusClient(connectionstring, clientOptions);
+
+			_receiverClient = !string.IsNullOrEmpty(queueName)
+				                  ? _mgmt.CreateReceiver(queueName)
+				                  : _mgmt.CreateReceiver(topicName, subscriptionName);
+
+			_messageHandlerOptions = processorOptions ??
+			                         new ServiceBusProcessorOptions {
+				                         AutoCompleteMessages = false,
+				                         /*
+				                          * In fact, what the property actually means is the maximum about of time they lock renewal will happen for internally on the subscription client.
+				                          * So if you set this to 24 hours e.g. Timespan.FromHours(24) and your processing was to take 12 hours, it would be renewed. However, if you set
+				                          * this to 12 hours using Timespan.FromHours(12) and your code ran for 24, when you went to complete the message it would give a lockLost exception
+				                          * (as I was getting above over shorter intervals!).
+				                          *
+				                          * in fact, Microsoft's implementation runs a background task that periodically renews the message lock until it expires.
+				                          */
+				                         MaxAutoLockRenewalDuration = TimeSpan.FromMinutes(10), //should be in fact called "max processing time"
+				                         MaxConcurrentCalls = 1
+			                         };
+
+			_autoComplete = _messageHandlerOptions.AutoCompleteMessages;
+
+			//note: we can't use management SDK as it requires high priviledged SP in Azure
+		}
+
+		public async Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages,
+		                                       CancellationToken cancellationToken = default) {
+			if (_autoComplete)
+				return;
+
+			await Task.WhenAll(messages.Select(ConfirmAsync)).ConfigureAwait(false);
+		}
+
+		private async Task ConfirmAsync(IQueueMessage message) {
+			//delete the message and get the deleted element, very nice method!
+			if (!_messageIdToBrokeredMessage.TryRemove(message.Id, out ServiceBusReceivedMessage bm))
+				return;
+
+			await _receiverClient.CompleteMessageAsync(bm).ConfigureAwait(false);
+		}
+
+		public Task<int> GetMessageCountAsync() => throw new NotSupportedException();
+
+
+		public async Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription,
+		                                  CancellationToken cancellationToken = default) {
+			if (_autoComplete)
+				return;
+
+			if (!_messageIdToBrokeredMessage.TryRemove(message.Id, out ServiceBusReceivedMessage bm))
+				return;
+
+			await _receiverClient.DeadLetterMessageAsync(bm, cancellationToken: cancellationToken)
+			                     .ConfigureAwait(false);
+		}
+
+		public async Task KeepAliveAsync(IQueueMessage message, TimeSpan? timeToLive = null,
+		                                 CancellationToken cancellationToken = default) {
+			if (_autoComplete)
+				return;
+
+			if (!_messageIdToBrokeredMessage.TryGetValue(message.Id, out ServiceBusReceivedMessage bm))
+				return;
+
+			await _receiverClient.RenewMessageLockAsync(bm, cancellationToken).ConfigureAwait(false);
+		}
+
+		public Task<ITransaction> OpenTransactionAsync() {
+			return Task.FromResult(EmptyTransaction.Instance);
+		}
+
+
+		public async Task StartMessagePumpAsync(
+			Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessageAsync,
+			int maxBatchSize = 1,
+			CancellationToken cancellationToken = default) {
+			_onMessage = onMessageAsync ?? throw new ArgumentNullException(nameof(onMessageAsync));
+
+			var processor = !string.IsNullOrEmpty(_queueName)
+				                ? _mgmt.CreateProcessor(_queueName, _messageHandlerOptions)
+				                : _mgmt.CreateProcessor(_topicName, _subscriptionName, _messageHandlerOptions);
+
+			processor.UpdatePrefetchCount(maxBatchSize);
+
+			cancellationToken.Register(() => {
+				processor.ProcessMessageAsync -= ProcessorOnProcessMessage;
+				processor.ProcessErrorAsync   -= DefaultExceptionReceiverHandler;
+				processor.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
+				processor.DisposeAsync();
+			});
+
+			processor.ProcessMessageAsync += ProcessorOnProcessMessage;
+			processor.ProcessErrorAsync   += DefaultExceptionReceiverHandler;
+
+			await processor.StartProcessingAsync(cancellationToken).ConfigureAwait(false);
+		}
+
+		private async Task ProcessorOnProcessMessage(ProcessMessageEventArgs args) {
+			IQueueMessage qm = Converter.ToQueueMessage(args.Message);
+			if (!_autoComplete)
+				_messageIdToBrokeredMessage[qm.Id] = args.Message;
+
+			await _onMessage(new[] { qm }, args.CancellationToken).ConfigureAwait(false);
+		}
+
+		private Task DefaultExceptionReceiverHandler(ProcessErrorEventArgs args) {
+			if (args?.Exception is OperationCanceledException) {
+				// operation cancelled, ignore
+			}
+
+			if (args != null) {
+				// the error source tells me at what point in the processing an error occurred
+				Console.WriteLine(args.ErrorSource);
+				// the fully qualified namespace is available
+				Console.WriteLine(args.FullyQualifiedNamespace);
+				// as well as the entity path
+				Console.WriteLine(args.EntityPath);
+				Console.WriteLine(args.Exception.ToString());
+			}
+
+			//extra handling code
+			return Task.FromResult(true);
+		}
+
+		public async Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(
+			int maxMessages, CancellationToken cancellationToken = default) {
+			var peek = await _receiverClient
+			       .PeekMessagesAsync(maxMessages, cancellationToken: cancellationToken)
+			       .ConfigureAwait(false);
+
+			return peek.Select(Converter.ToQueueMessage).ToList();
+		}
+
+		public void Dispose() {
+			_receiverClient.CloseAsync();
+			_mgmt.DisposeAsync();
+		}
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusTopicReceiver.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusTopicReceiver.cs
@@ -1,0 +1,14 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace FluentStorage.Azure.Messaging.ServiceBus.Receivers {
+	/// <summary>
+	/// Implements message receiver on Azure Service Bus Queues
+	/// </summary>
+	internal class AzureServiceBusTopicReceiver : AzureServiceBusReceiver {
+		internal AzureServiceBusTopicReceiver(string connectionString, string topicName, string subscriptionName,
+		                                       ServiceBusClientOptions clientOptions = null,
+		                                       ServiceBusProcessorOptions processorOptions = null)
+			: base(connectionString, "", topicName, subscriptionName, clientOptions, processorOptions) {
+		}
+	}
+}

--- a/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusTopicReceiver.cs
+++ b/FluentStorage.Azure.Messaging.ServiceBus/Receivers/AzureServiceBusTopicReceiver.cs
@@ -4,8 +4,8 @@ namespace FluentStorage.Azure.Messaging.ServiceBus.Receivers {
 	/// <summary>
 	/// Implements message receiver on Azure Service Bus Queues
 	/// </summary>
-	internal class AzureServiceBusTopicReceiver : AzureServiceBusReceiver {
-		internal AzureServiceBusTopicReceiver(string connectionString, string topicName, string subscriptionName,
+	class AzureServiceBusTopicReceiver : AzureServiceBusReceiver {
+		public AzureServiceBusTopicReceiver(string connectionString, string topicName, string subscriptionName,
 		                                       ServiceBusClientOptions clientOptions = null,
 		                                       ServiceBusProcessorOptions processorOptions = null)
 			: base(connectionString, "", topicName, subscriptionName, clientOptions, processorOptions) {

--- a/FluentStorage.Azure.Queues/AzureStorageQueueMessenger.cs
+++ b/FluentStorage.Azure.Queues/AzureStorageQueueMessenger.cs
@@ -140,7 +140,7 @@ namespace FluentStorage.Azure.Queues {
 			}
 		}
 
-		public async Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			CloudQueue queue = await GetQueueAsync(channelName).ConfigureAwait(false);
 
 			await Task.WhenAll(messages.Select(async m => {
@@ -150,7 +150,7 @@ namespace FluentStorage.Azure.Queues {
 			})).ConfigureAwait(false);
 		}
 
-		public async Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
@@ -166,7 +166,7 @@ namespace FluentStorage.Azure.Queues {
 
 		}
 
-		public async Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		public async Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
@@ -182,7 +182,7 @@ namespace FluentStorage.Azure.Queues {
 			if (batch == null)
 				return new QueueMessage[0];
 
-			List<QueueMessage> result = batch.Select(Converter.ToQueueMessage).ToList();
+			List<IQueueMessage> result = batch.Select(Converter.ToQueueMessage).ToList();
 			return result;
 		}
 
@@ -191,7 +191,7 @@ namespace FluentStorage.Azure.Queues {
 
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 
 

--- a/FluentStorage.Azure.Queues/Converter.cs
+++ b/FluentStorage.Azure.Queues/Converter.cs
@@ -13,7 +13,7 @@ namespace FluentStorage.Azure.Queues {
 		private static readonly Guid CustomFlag = new Guid("820e7dc0-46a3-4177-a241-cdac97275ca9");
 		private static readonly byte[] CustomFlagBytes = CustomFlag.ToByteArray();
 
-		public static CloudQueueMessage ToCloudQueueMessage(QueueMessage message) {
+		public static CloudQueueMessage ToCloudQueueMessage(IQueueMessage message) {
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 
@@ -49,7 +49,7 @@ namespace FluentStorage.Azure.Queues {
 			return result;
 		}
 
-		public static QueueMessage ToQueueMessage(CloudQueueMessage message) {
+		public static IQueueMessage ToQueueMessage(CloudQueueMessage message) {
 			if (message == null) return null;
 
 			byte[] mb = message.AsBytes;

--- a/FluentStorage.Azure.ServiceBus/Converter.cs
+++ b/FluentStorage.Azure.ServiceBus/Converter.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Azure.ServiceBus;
 using System;
 using System.Collections.Generic;
+using FluentStorage.Messaging;
 using QueueMessage = FluentStorage.Messaging.QueueMessage;
 
 namespace FluentStorage.Azure.ServiceBus {
 	static class Converter {
-		public static Message ToMessage(QueueMessage message) {
+		public static Message ToMessage(IQueueMessage message) {
 			if (message == null)
 				throw new ArgumentNullException(nameof(message));
 
@@ -21,7 +22,7 @@ namespace FluentStorage.Azure.ServiceBus {
 			return result;
 		}
 
-		public static QueueMessage ToQueueMessage(Message message) {
+		public static IQueueMessage ToQueueMessage(Message message) {
 			string id = message.MessageId ?? message.SystemProperties.SequenceNumber.ToString();
 
 			var result = new QueueMessage(id, message.Body);

--- a/FluentStorage.Azure.ServiceBus/Messaging/AzureServiceBusMessenger.cs
+++ b/FluentStorage.Azure.ServiceBus/Messaging/AzureServiceBusMessenger.cs
@@ -114,7 +114,7 @@ namespace FluentStorage.Azure.ServiceBus.Messaging {
 		}
 
 
-		public async Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			ISenderClient client = CreateOrGetSenderClient(channelName);
 
 			IList<Message> sbmsg = messages.Select(Converter.ToMessage).ToList();
@@ -181,7 +181,7 @@ namespace FluentStorage.Azure.ServiceBus.Messaging {
 			return channels;
 		}
 
-		public async Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
@@ -191,7 +191,7 @@ namespace FluentStorage.Azure.ServiceBus.Messaging {
 			return messages.Select(Converter.ToQueueMessage).ToList();
 		}
 
-		public async Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		public async Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
@@ -214,7 +214,7 @@ namespace FluentStorage.Azure.ServiceBus.Messaging {
 			await _mgmt.CreateQueueAsync(name).ConfigureAwait(false);
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 
 

--- a/FluentStorage.Azure.ServiceFabric/Blob/ServiceFabricReliableDictionaryBlobStorage.cs
+++ b/FluentStorage.Azure.ServiceFabric/Blob/ServiceFabricReliableDictionaryBlobStorage.cs
@@ -20,10 +20,10 @@ namespace FluentStorage.Microsoft.ServiceFabric.Blobs {
 			_collectionName = collectionName ?? throw new ArgumentNullException(nameof(collectionName));
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
+		public async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			if (options == null) options = new ListOptions();
 
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 
 			using (ServiceFabricTransaction tx = GetTransaction()) {
 				IReliableDictionary<string, byte[]> coll = await OpenCollectionAsync().ConfigureAwait(false);
@@ -147,10 +147,10 @@ namespace FluentStorage.Microsoft.ServiceFabric.Blobs {
 			return result;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken) {
 			GenericValidation.CheckBlobFullPaths(fullPaths);
 
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 
 			using (ServiceFabricTransaction tx = GetTransaction()) {
 				IReliableDictionary<string, byte[]> coll = await OpenCollectionAsync().ConfigureAwait(false);
@@ -172,7 +172,7 @@ namespace FluentStorage.Microsoft.ServiceFabric.Blobs {
 			return result;
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 

--- a/FluentStorage.Azure.ServiceFabric/Messaging/AbstractServiceFabricReliableQueueReceiver.cs
+++ b/FluentStorage.Azure.ServiceFabric/Messaging/AbstractServiceFabricReliableQueueReceiver.cs
@@ -38,7 +38,7 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
 		public async Task StartMessagePumpAsync(
-		   Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync,
+		   Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessageAsync,
 		   int maxBatchSize = 1,
 		   CancellationToken cancellationToken = default)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
@@ -48,24 +48,24 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
 		}
 
-		public Task ConfirmMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			return Task.FromResult(true);
 		}
 
-		public Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
+		public Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
 			return Task.FromResult(true);
 		}
 
 		protected abstract Task<ConditionalValue<byte[]>> TryDequeueAsync(ServiceFabricTransaction tx, IReliableState collectionBase, CancellationToken cancellationToken);
 
-		private async Task ReceiveMessagesAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessage, int maxBatchSize, CancellationToken cancellationToken) {
+		private async Task ReceiveMessagesAsync(Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessage, int maxBatchSize, CancellationToken cancellationToken) {
 
 			while (!cancellationToken.IsCancellationRequested && !_disposed) {
 				try {
 					using (var tx = new ServiceFabricTransaction(_stateManager, null)) {
 						IReliableState collection = await GetCollectionAsync().ConfigureAwait(false);
 
-						var messages = new List<QueueMessage>();
+						var messages = new List<IQueueMessage>();
 
 						while (messages.Count < maxBatchSize) {
 							ConditionalValue<byte[]> message = await TryDequeueAsync(tx, collection, cancellationToken).ConfigureAwait(false);
@@ -109,7 +109,7 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 		}
 
 		protected abstract Task<IReliableState> GetCollectionAsync();
-		public Task KeepAliveAsync(QueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
-		public Task<IReadOnlyCollection<QueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task KeepAliveAsync(IQueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 	}
 }

--- a/FluentStorage.Azure.ServiceFabric/Messaging/ServiceFabricReliableConcurrentQueuePublisher.cs
+++ b/FluentStorage.Azure.ServiceFabric/Messaging/ServiceFabricReliableConcurrentQueuePublisher.cs
@@ -20,7 +20,7 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 			_timeout = timeout;
 		}
 
-		public async Task PutMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken) {
+		public async Task PutMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken) {
 			IReliableConcurrentQueue<byte[]> collection = await _stateManager.GetOrAddAsync<IReliableConcurrentQueue<byte[]>>(_queueName).ConfigureAwait(false);
 
 			using (var tx = new ServiceFabricTransaction(_stateManager, null)) {
@@ -41,10 +41,10 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 		public Task<IReadOnlyCollection<string>> ListChannelsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task DeleteChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task<long> GetMessageCountAsync(string channelName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 	}
 }

--- a/FluentStorage.Azure.ServiceFabric/Messaging/ServiceFabricReliableQueuePublisher.cs
+++ b/FluentStorage.Azure.ServiceFabric/Messaging/ServiceFabricReliableQueuePublisher.cs
@@ -20,7 +20,7 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 			_timeout = timeout == null ? TimeSpan.FromSeconds(4) : timeout.Value;
 		}
 
-		public async Task PutMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken) {
+		public async Task PutMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken) {
 			IReliableQueue<byte[]> collection = await _stateManager.GetOrAddAsync<IReliableQueue<byte[]>>(_queueName).ConfigureAwait(false);
 
 			using (var tx = new ServiceFabricTransaction(_stateManager, null)) {
@@ -41,10 +41,10 @@ namespace FluentStorage.Microsoft.ServiceFabric.Messaging {
 		public Task<IReadOnlyCollection<string>> ListChannelsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task DeleteChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task<long> GetMessageCountAsync(string channelName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 	}
 }

--- a/FluentStorage.Databricks/DbfsStorage.cs
+++ b/FluentStorage.Databricks/DbfsStorage.cs
@@ -44,11 +44,11 @@ namespace FluentStorage.Databricks {
 			return true;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			return await Task.WhenAll(fullPaths.Select(fp => GetBlobAsync(fp))).ConfigureAwait(false);
 		}
 
-		private async Task<Blob> GetBlobAsync(string fullPath) {
+		private async Task<IBlob> GetBlobAsync(string fullPath) {
 			fullPath = StoragePath.Normalize(fullPath);
 			FileInfo status;
 			try {
@@ -63,11 +63,11 @@ namespace FluentStorage.Databricks {
 			};
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
 			if (options == null)
 				options = new ListOptions();
 
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 
 			await ListFolderAsync(options.FolderPath, result, options).ConfigureAwait(false);
 
@@ -78,7 +78,7 @@ namespace FluentStorage.Databricks {
 			return result;
 		}
 
-		private async Task ListFolderAsync(string path, List<Blob> container, ListOptions options) {
+		private async Task ListFolderAsync(string path, List<IBlob> container, ListOptions options) {
 			IEnumerable<FileInfo> objects;
 
 			try {
@@ -131,7 +131,7 @@ namespace FluentStorage.Databricks {
 			await _dbfs.Upload(fullPath, true, dataStream).ConfigureAwait(false);
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
 		public void Dispose() {
 

--- a/FluentStorage.Databricks/JobsStorage.cs
+++ b/FluentStorage.Databricks/JobsStorage.cs
@@ -17,7 +17,7 @@ namespace FluentStorage.Databricks {
 		protected override bool CanListHierarchy => false;
 
 
-		protected override async Task<IReadOnlyCollection<Blob>> ListAtAsync(
+		protected override async Task<IReadOnlyCollection<IBlob>> ListAtAsync(
 		   string path, ListOptions options, CancellationToken cancellationToken) {
 			if (StoragePath.IsRootPath(path)) {
 				IEnumerable<Job> jobs = await _jobs.List().ConfigureAwait(false);
@@ -31,7 +31,7 @@ namespace FluentStorage.Databricks {
 			string jobName = StoragePath.Split(path)[0];
 			long? jobId = await GetJobIdFromJobNameAsync(jobName).ConfigureAwait(false);
 			IReadOnlyCollection<Run> allRuns = await GetAllJobRunsAsync(jobId.Value).ConfigureAwait(false);
-			List<Blob> rr = allRuns.Select(r => ToBlob(jobName, r)).ToList();
+			List<IBlob> rr = allRuns.Select(r => ToBlob(jobName, r)).ToList();
 			rr.Reverse();
 			return rr;
 		}
@@ -85,7 +85,7 @@ namespace FluentStorage.Databricks {
 			return null;
 		}
 
-		private async Task<Blob> ToBlobAsync(Job dbJob) {
+		private async Task<IBlob> ToBlobAsync(Job dbJob) {
 			var blob = new Blob(dbJob.Settings.Name, BlobItemKind.Folder);
 			blob.CreatedTime = blob.LastModificationTime = dbJob.CreatedTime;
 			blob.TryAddProperties(
@@ -112,7 +112,7 @@ namespace FluentStorage.Databricks {
 			return blob;
 		}
 
-		private static Blob ToBlob(string jobName, Run dbRun) {
+		private static IBlob ToBlob(string jobName, Run dbRun) {
 			var blob = new Blob(jobName, dbRun.RunId.ToString(), BlobItemKind.File);
 			blob.LastModificationTime = dbRun.EndTime ?? dbRun.StartTime;
 			AddProperties(blob, dbRun);

--- a/FluentStorage.Databricks/SecretStorage.cs
+++ b/FluentStorage.Databricks/SecretStorage.cs
@@ -31,9 +31,9 @@ namespace FluentStorage.Databricks {
 
 		protected override bool CanListHierarchy => false;
 
-		protected override async Task<IReadOnlyCollection<Blob>> ListAtAsync(
+		protected override async Task<IReadOnlyCollection<IBlob>> ListAtAsync(
 		   string path, ListOptions options, CancellationToken cancellationToken) {
-			var r = new List<Blob>();
+			var r = new List<IBlob>();
 
 			// listing from "/secrets"
 			if (StoragePath.IsRootPath(path)) {

--- a/FluentStorage.Databricks/WorkspaceStorage.cs
+++ b/FluentStorage.Databricks/WorkspaceStorage.cs
@@ -18,20 +18,20 @@ namespace FluentStorage.Databricks {
 
 		protected override bool CanListHierarchy => false;
 
-		protected override async Task<IReadOnlyCollection<Blob>> ListAtAsync(string path, ListOptions options, CancellationToken cancellationToken) {
+		protected override async Task<IReadOnlyCollection<IBlob>> ListAtAsync(string path, ListOptions options, CancellationToken cancellationToken) {
 			IEnumerable<ObjectInfo> objects = await _api.List(StoragePath.Normalize(path)).ConfigureAwait(false);
 
 			return objects.Select(ToBlob).Where(b => b != null).ToList();
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="fullPath"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <remarks>
-		/// 
+		///
 		/// </remarks>
 		public override async Task<Stream> OpenReadAsync(string fullPath, CancellationToken cancellationToken = default) {
 			if (fullPath is null)

--- a/FluentStorage.FTP/FluentFtpBlobStorage.cs
+++ b/FluentStorage.FTP/FluentFtpBlobStorage.cs
@@ -42,7 +42,7 @@ namespace FluentStorage.FTP {
 			return _client;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
 			if (options == null)
@@ -50,7 +50,7 @@ namespace FluentStorage.FTP {
 
 			FtpListItem[] items = await client.GetListing(options.FolderPath).ConfigureAwait(false);
 
-			List<Blob> results = new List<Blob>();
+			List<IBlob> results = new List<IBlob>();
 			foreach (FtpListItem item in items) {
 				if (options.FilePrefix != null && !item.Name.StartsWith(options.FilePrefix)) {
 					continue;
@@ -118,10 +118,10 @@ namespace FluentStorage.FTP {
 			return results;
 		}
 
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
 			AsyncFtpClient client = await GetClientAsync().ConfigureAwait(false);
 
-			List<Blob> results = new List<Blob>();
+			List<IBlob> results = new List<IBlob>();
 			foreach (string path in ids) {
 				string cpath = StoragePath.Normalize(path);
 				string parentPath = StoragePath.GetParent(cpath);
@@ -143,7 +143,7 @@ namespace FluentStorage.FTP {
 			return results;
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 

--- a/FluentStorage.GCP/Blobs/GConvert.cs
+++ b/FluentStorage.GCP/Blobs/GConvert.cs
@@ -49,7 +49,7 @@ namespace FluentStorage.Gcp.CloudStorage.Blobs {
 			return blob;
 		}
 
-		public static IEnumerable<Blob> ToBlobs(IEnumerable<Object> objects, ListOptions options) {
+		public static IEnumerable<IBlob> ToBlobs(IEnumerable<Object> objects, ListOptions options) {
 			foreach (Object obj in objects) {
 				Blob item = ToBlob(obj);
 
@@ -65,8 +65,8 @@ namespace FluentStorage.Gcp.CloudStorage.Blobs {
 			yield break;
 		}
 
-		public static async Task<IReadOnlyCollection<Blob>> ToBlobsAsync(PagedAsyncEnumerable<Objects, Object> pae, ListOptions options) {
-			var result = new List<Blob>();
+		public static async Task<IReadOnlyCollection<IBlob>> ToBlobsAsync(PagedAsyncEnumerable<Objects, Object> pae, ListOptions options) {
+			var result = new List<IBlob>();
 
 #pragma warning disable IDE0008 // Use explicit type (async enumerator conflict)
 			using (var enumerator = pae.GetEnumerator())

--- a/FluentStorage.Tests.Console/Program.cs
+++ b/FluentStorage.Tests.Console/Program.cs
@@ -25,7 +25,7 @@ namespace FluentStorage.ConsoleRunner {
 	}
 
 	class Processor : IMessageProcessor {
-		public async Task ProcessMessagesAsync(IReadOnlyCollection<QueueMessage> messages) {
+		public async Task ProcessMessagesAsync(IReadOnlyCollection<IQueueMessage> messages) {
 			foreach (QueueMessage qm in messages) {
 				Console.WriteLine($"received {qm.Id}: {qm.StringContent}");
 			}

--- a/FluentStorage.Tests.Integration/Azure/LeakyAdlsGen2StorageTest.cs
+++ b/FluentStorage.Tests.Integration/Azure/LeakyAdlsGen2StorageTest.cs
@@ -77,7 +77,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 			await _storage.WriteTextAsync(fsName + "/fff", "test");
 
-			Blob fsBlob = await _storage.GetBlobAsync(fsName);
+			IBlob fsBlob = await _storage.GetBlobAsync(fsName);
 
 
 		}
@@ -235,7 +235,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 		public async Task InitializeAsync() {
 			//drop all blobs in test storage
-			IReadOnlyCollection<Blob> topLevel =
+			IReadOnlyCollection<IBlob> topLevel =
 			   (await _storage.ListAsync(recurse: false, folderPath: Filesystem)).ToList();
 
 			try {

--- a/FluentStorage.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
+++ b/FluentStorage.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
@@ -34,7 +34,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 			//check we can connect and list containers
 			IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
-			IReadOnlyCollection<Blob> containers = await sasInstance.ListAsync(StoragePath.RootFolderPath);
+			IReadOnlyCollection<IBlob> containers = await sasInstance.ListAsync(StoragePath.RootFolderPath);
 			Assert.True(containers.Count > 0);
 		}
 
@@ -50,7 +50,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 		   //check we can connect and list test file in the root
 		   IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
-		   IReadOnlyCollection<Blob> blobs = await sasInstance.ListAsync(StoragePath.RootFolderPath);
+		   IReadOnlyCollection<IBlob> blobs = await sasInstance.ListAsync(StoragePath.RootFolderPath);
 		   Blob testBlob = blobs.FirstOrDefault(b => b.FullPath == fileName);
 		   Assert.NotNull(testBlob);
 		}*/
@@ -156,7 +156,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 		[Fact]
 		public async Task Top_level_folders_are_containers() {
-			IReadOnlyCollection<Blob> containers = await _native.ListAsync();
+			IReadOnlyCollection<IBlob> containers = await _native.ListAsync();
 
 			foreach (Blob container in containers) {
 				Assert.Equal(BlobItemKind.Folder, container.Kind);
@@ -170,7 +170,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 			string containerName = Guid.NewGuid().ToString();
 			await _native.WriteTextAsync($"{containerName}/test.txt", "test");
 
-			IReadOnlyCollection<Blob> containers = await _native.ListAsync();
+			IReadOnlyCollection<IBlob> containers = await _native.ListAsync();
 			Assert.Contains(containers, c => c.Name == containerName);
 
 			await _native.DeleteAsync(containerName);
@@ -181,7 +181,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 		/*[Fact]
 		public async Task Analytics_has_logs_container()
 		{
-		   IReadOnlyCollection<Blob> containers = await _native.ListAsync();
+		   IReadOnlyCollection<IBlob> containers = await _native.ListAsync();
 		   Assert.Contains(containers, c => c.Name == "$logs");
 		}*/
 

--- a/FluentStorage.Tests.Integration/Azure/LeakyDatabricksStorageTest.cs
+++ b/FluentStorage.Tests.Integration/Azure/LeakyDatabricksStorageTest.cs
@@ -21,32 +21,32 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 		[Fact]
 		public async Task List_root() {
-			IReadOnlyCollection<Blob> roots = await _storage.ListAsync();
+			IReadOnlyCollection<IBlob> roots = await _storage.ListAsync();
 
 			Assert.Equal(2, roots.Count); // dbfs + notebooks
 		}
 
 		[Fact]
 		public async Task List_dbfs_root() {
-			IReadOnlyCollection<Blob> roots = await _storage.ListAsync("/dbfs");
+			IReadOnlyCollection<IBlob> roots = await _storage.ListAsync("/dbfs");
 
 			Assert.True(roots.Count > 0);
 		}
 
 		[Fact]
 		public async Task List_notebooks_root() {
-			IReadOnlyCollection<Blob> roots = await _storage.ListAsync("/workspace");
+			IReadOnlyCollection<IBlob> roots = await _storage.ListAsync("/workspace");
 
 			Assert.True(roots.Count > 0);
 		}
 
 		[Fact]
 		public async Task Export_notebook() {
-			IReadOnlyCollection<Blob> roots = await _storage.ListAsync("/workspace", recurse: true);
-			Blob notebook = roots.FirstOrDefault(b => b.TryGetProperty("ObjectType", out ObjectType? ot) && ot == ObjectType.NOTEBOOK);
+			IReadOnlyCollection<IBlob> roots = await _storage.ListAsync("/workspace", recurse: true);
+			IBlob notebook = roots.FirstOrDefault(b => b.TryGetProperty("ObjectType", out ObjectType? ot) && ot == ObjectType.NOTEBOOK);
 			Assert.NotNull(notebook);
 
-			string defaultSource = await _storage.ReadTextAsync(notebook);
+			string defaultSource = await _storage.ReadTextAsync(notebook.FullPath);
 			string sourceSource = await _storage.ReadTextAsync(notebook + "#source");
 			string jupyterSource = await _storage.ReadTextAsync(notebook + "#jupyter");
 			string htmlSource = await _storage.ReadTextAsync(notebook + "#html");
@@ -63,7 +63,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 		public async Task List_secret_scopes() {
 			await _storage.CreateSecretsScope("ivan");
 
-			IReadOnlyCollection<Blob> scopes = await _storage.ListAsync("/secrets");
+			IReadOnlyCollection<IBlob> scopes = await _storage.ListAsync("/secrets");
 
 			Assert.True(scopes.Count > 0);
 			Assert.Contains("ivan", scopes.Select(s => s.Name));
@@ -74,7 +74,7 @@ namespace FluentStorage.Tests.Integration.Azure {
 			await _storage.CreateSecretsScope("ivan");
 			await _storage.WriteTextAsync("/secrets/ivan/one", "dfadfd");
 
-			IReadOnlyCollection<Blob> secrets = await _storage.ListAsync("/secrets/ivan");
+			IReadOnlyCollection<IBlob> secrets = await _storage.ListAsync("/secrets/ivan");
 			Assert.True(secrets.Count > 0);
 		}
 
@@ -91,24 +91,24 @@ namespace FluentStorage.Tests.Integration.Azure {
 
 		[Fact]
 		public async Task List_jobs() {
-			IReadOnlyCollection<Blob> jobs = await _storage.ListAsync("/jobs");
+			IReadOnlyCollection<IBlob> jobs = await _storage.ListAsync("/jobs");
 
 			Assert.True(jobs.Count > 0);
 		}
 
 		[Fact]
 		public async Task List_job_runs() {
-			Blob job = (await _storage.ListAsync("/jobs")).First();
+			IBlob job = (await _storage.ListAsync("/jobs")).First();
 
-			IReadOnlyCollection<Blob> runs = await _storage.ListAsync(job);
+			IReadOnlyCollection<IBlob> runs = await _storage.ListAsync(job.FullPath);
 
 			Assert.True(runs.Count > 0);
 		}
 
 		[Fact]
 		public async Task Download_job_run_output() {
-			Blob job = (await _storage.ListAsync("/jobs")).First();
-			Blob run = (await _storage.ListAsync(job)).Last();
+			IBlob job = (await _storage.ListAsync("/jobs")).First();
+			IBlob run = (await _storage.ListAsync(job.FullPath)).Last();
 
 			string output = await _storage.ReadTextAsync($"/jobs/{job.Name}/{run.Name}");
 		}

--- a/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
+++ b/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\FluentStorage.Azure.DataLake.Store\FluentStorage.Azure.DataLake.csproj" />
     <ProjectReference Include="..\FluentStorage.Azure.EventHub\FluentStorage.Azure.EventHub.csproj" />
     <ProjectReference Include="..\FluentStorage.Azure.KeyVault\FluentStorage.Azure.KeyVault.csproj" />
+    <ProjectReference Include="..\FluentStorage.Azure.Messaging.ServiceBus\FluentStorage.Azure.Messaging.ServiceBus.csproj" />
     <ProjectReference Include="..\FluentStorage.Azure.Queues\FluentStorage.Azure.Queues.csproj" />
     <ProjectReference Include="..\FluentStorage.Azure.ServiceBus\FluentStorage.Azure.ServiceBus.csproj" />
     <ProjectReference Include="..\FluentStorage.Azure.ServiceFabric\FluentStorage.Azure.ServiceFabric.csproj" />

--- a/FluentStorage.Tests.Integration/Trio/BlobFixture.cs
+++ b/FluentStorage.Tests.Integration/Trio/BlobFixture.cs
@@ -41,7 +41,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 			//drop all blobs in test storage
 
-			IReadOnlyCollection<Blob> topLevel = (await Storage.ListAsync(folderPath: BlobPrefix, recurse: false)).ToList();
+			IReadOnlyCollection<IBlob> topLevel = (await Storage.ListAsync(folderPath: BlobPrefix, recurse: false)).ToList();
 
 			try {
 				await Storage.DeleteAsync(topLevel.Select(f => f.FullPath));

--- a/FluentStorage.Tests.Integration/Trio/BlobTest.cs
+++ b/FluentStorage.Tests.Integration/Trio/BlobTest.cs
@@ -54,7 +54,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 			await _storage.WriteTextAsync(targetId, "test");
 
-			IReadOnlyCollection<Blob> rootContent = await _storage.ListAsync();
+			IReadOnlyCollection<IBlob> rootContent = await _storage.ListAsync();
 
 			Assert.NotEmpty(rootContent);
 		}
@@ -73,7 +73,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			await _storage.WriteTextAsync(id2, RandomGenerator.RandomString);
 			await _storage.WriteTextAsync(id3, RandomGenerator.RandomString);
 
-			IReadOnlyCollection<Blob> items = (await _storage.ListAsync(new ListOptions { FolderPath = _blobPrefix, FilePrefix = prefix }));
+			IReadOnlyCollection<IBlob> items = (await _storage.ListAsync(new ListOptions { FolderPath = _blobPrefix, FilePrefix = prefix }));
 			Assert.Equal(2 + countBefore, items.Count); //2 files + containing folder
 		}
 
@@ -83,11 +83,11 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 			await _storage.WriteTextAsync(id, RandomGenerator.RandomString);
 
-			List<Blob> items = (await _storage.ListAsync(new ListOptions { FolderPath = _blobPrefix, Recurse = false })).ToList();
+			List<IBlob> items = (await _storage.ListAsync(new ListOptions { FolderPath = _blobPrefix, Recurse = false })).ToList();
 
 			Assert.True(items.Count > 0);
 
-			Blob tid = items.FirstOrDefault(i => i.FullPath == id);
+			IBlob tid = items.FirstOrDefault(i => i.FullPath == id);
 			Assert.NotNull(tid);
 		}
 
@@ -103,7 +103,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				await _storage.WriteTextAsync(id2, RandomGenerator.RandomString);
 				await _storage.WriteTextAsync(id3, RandomGenerator.RandomString);
 
-				IReadOnlyCollection<Blob> items = await _storage.ListAsync(recurse: true, folderPath: folderPath);
+				IReadOnlyCollection<IBlob> items = await _storage.ListAsync(recurse: true, folderPath: folderPath);
 				Assert.Equal(4, items.Count); //1.txt + sub (folder) + 2.txt + 3.txt
 
 			}
@@ -114,7 +114,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 		[Fact]
 		public async Task List_InNonExistingFolder_EmptyCollection() {
-			IEnumerable<Blob> objects = await _storage.ListAsync(new ListOptions { FolderPath = RandomBlobPath() });
+			IEnumerable<IBlob> objects = await _storage.ListAsync(new ListOptions { FolderPath = RandomBlobPath() });
 
 			Assert.NotNull(objects);
 			Assert.True(objects.Count() == 0);
@@ -122,7 +122,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 		[Fact]
 		public async Task List_FilesInNonExistingFolder_EmptyCollection() {
-			IEnumerable<Blob> objects = await _storage.ListFilesAsync(new ListOptions { FolderPath = RandomBlobPath() });
+			IEnumerable<IBlob> objects = await _storage.ListFilesAsync(new ListOptions { FolderPath = RandomBlobPath() });
 
 			Assert.NotNull(objects);
 			Assert.True(objects.Count() == 0);
@@ -156,7 +156,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			await _storage.WriteTextAsync(id2, RandomGenerator.RandomString);
 
 			//dump compare
-			IReadOnlyCollection<Blob> files = await _storage.ListFilesAsync(new ListOptions {
+			IReadOnlyCollection<IBlob> files = await _storage.ListFilesAsync(new ListOptions {
 				FolderPath = _blobPrefix,
 				Recurse = true
 			});
@@ -186,7 +186,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			}
 
 			//act
-			IReadOnlyCollection<Blob> blobs = await _storage.ListAsync(folderPath: _blobPrefix);
+			IReadOnlyCollection<IBlob> blobs = await _storage.ListAsync(folderPath: _blobPrefix);
 
 			//assert
 			Assert.True(blobs.Count >= count, $"expected over {count}, but received only {blobs.Count}");
@@ -200,7 +200,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				await _storage.WriteTextAsync(sub + "one.txt", "test");
 				await _storage.WriteTextAsync(sub + "sub/two.txt", "test");
 
-				IReadOnlyCollection<Blob> subItems = await _storage.ListAsync(recurse: false, folderPath: sub);
+				IReadOnlyCollection<IBlob> subItems = await _storage.ListAsync(recurse: false, folderPath: sub);
 				Assert.Equal(2, subItems.Count);
 
 
@@ -219,7 +219,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 			await _storage.WriteTextAsync(id, content);
 
-			Blob meta = await _storage.GetBlobAsync(id);
+			IBlob meta = await _storage.GetBlobAsync(id);
 
 			long size = Encoding.UTF8.GetBytes(content).Length;
 			string md5 = content.MD5();
@@ -236,7 +236,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 		public async Task GetBlob_doesnt_exist_returns_null() {
 			string id = RandomBlobPath();
 
-			Blob meta = (await _storage.GetBlobsAsync(new[] { id })).First();
+			IBlob meta = (await _storage.GetBlobsAsync(new[] { id })).First();
 
 			Assert.Null(meta);
 		}
@@ -256,7 +256,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			string root = StoragePath.Split(id)[0];
 
 			try {
-				Blob rb = await _storage.GetBlobAsync(root);
+				IBlob rb = await _storage.GetBlobAsync(root);
 			}
 			catch (NotSupportedException) {
 
@@ -358,7 +358,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			}
 
 			//assert
-			IReadOnlyCollection<Blob> files = await _storage.ListAsync(prefix, recurse: true);
+			IReadOnlyCollection<IBlob> files = await _storage.ListAsync(prefix, recurse: true);
 			Assert.True(files.Count == 0);
 		}
 
@@ -370,7 +370,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			try {
 				await _storage.WriteTextAsync(file, "test");
 				await _storage.RenameAsync(file, StoragePath.Combine(prefix, "2"));
-				IReadOnlyCollection<Blob> list = await _storage.ListAsync(prefix);
+				IReadOnlyCollection<IBlob> list = await _storage.ListAsync(prefix);
 
 				Assert.Single(list);
 				Assert.True(list.First().Name == "2");
@@ -410,7 +410,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 			await _storage.RenameAsync(StoragePath.Combine(prefix, "old"), StoragePath.Combine(prefix, "new"));
 
-			IReadOnlyCollection<Blob> list = await _storage.ListAsync(prefix);
+			IReadOnlyCollection<IBlob> list = await _storage.ListAsync(prefix);
 		}
 
 		[Fact]
@@ -436,7 +436,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			blob.Metadata["fun"] = "no";
 
 			await _storage.WriteTextAsync(blob, "test");
-			Blob blob2 = await _storage.GetBlobAsync(blob);
+			IBlob blob2 = await _storage.GetBlobAsync(blob);
 
 			try {
 				await _storage.SetBlobAsync(blob);
@@ -474,7 +474,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			await _storage.SetBlobAsync(blob);
 
 			//test
-			Blob blob2 = await _storage.GetBlobAsync(blob);
+			IBlob blob2 = await _storage.GetBlobAsync(blob);
 			Assert.NotNull(blob2.Metadata);
 			Assert.Single(blob2.Metadata);
 			Assert.Equal("ivan2", blob2.Metadata["user"]);
@@ -496,7 +496,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			}
 
 			//test
-			Blob blob2 = await _storage.GetBlobAsync(blob);
+			IBlob blob2 = await _storage.GetBlobAsync(blob);
 			Assert.NotNull(blob2.Metadata);
 			Assert.Equal("ivan", blob2.Metadata["user"]);
 			Assert.Equal("no", blob2.Metadata["fun"]);
@@ -517,10 +517,10 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				return;
 			}
 
-			IReadOnlyCollection<Blob> all = await _storage.ListAsync(folderPath: blob.FolderPath, includeAttributes: true);
+			IReadOnlyCollection<IBlob> all = await _storage.ListAsync(folderPath: blob.FolderPath, includeAttributes: true);
 
 			//test
-			Blob blob2 = all.First(b => b.FullPath == blob.FullPath);
+			IBlob blob2 = all.First(b => b.FullPath == blob.FullPath);
 			Assert.NotNull(blob2.Metadata);
 			Assert.Equal("ivan", blob2.Metadata["user"]);
 			Assert.Equal("no", blob2.Metadata["fun"]);
@@ -546,7 +546,7 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			try {
 				await _storage.CreateFolderAsync(folderPath);
 
-				IReadOnlyCollection<Blob> files = await _storage.ListAsync(folderPath);
+				IReadOnlyCollection<IBlob> files = await _storage.ListAsync(folderPath);
 				Assert.True(files.Any());  //check dummy file exists
 			}
 			catch (NotSupportedException) {

--- a/FluentStorage.Tests.Integration/Trio/MessagingTest.Variations.cs
+++ b/FluentStorage.Tests.Integration/Trio/MessagingTest.Variations.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Amazon;
+using FluentStorage.Azure.Messaging.ServiceBus;
 using FluentStorage.Blobs;
 using FluentStorage.Messaging;
 using Xunit;
@@ -87,6 +88,32 @@ namespace FluentStorage.Tests.Integration.Messaging {
 
 	public class AzureServiceBusQueueTest : MessagingTest, IClassFixture<AzureServiceBusFixture> {
 		public AzureServiceBusQueueTest(AzureServiceBusFixture fixture) : base(fixture, "q/", "q/fxqueue") {
+		}
+	}
+
+	#endregion
+
+	#region [ Azure Messaging Service Bus ]
+
+	public class AzureMessagingServiceBusFixture : MessagingFixture {
+		protected override IMessenger CreateMessenger(ITestSettings settings) {
+			return StorageFactory.Messages.AzureMessagingServiceBus(settings.AzureServiceBusConnectionString);
+
+		}
+	}
+
+	public class AzureMessagingServiceBusTopicTest : MessagingTest, IClassFixture<AzureServiceBusFixture> {
+		public AzureMessagingServiceBusTopicTest(AzureServiceBusFixture fixture) : base(fixture, "t/", "t/fxtopic", receiveChannelSuffix: "/default") {
+		}
+	}
+
+	public class AzureMessagingServiceBusSubscriptionTest : MessagingTest, IClassFixture<AzureServiceBusFixture> {
+		public AzureMessagingServiceBusSubscriptionTest(AzureServiceBusFixture fixture) : base(fixture, "t/", "t/fxtopic/fxsubscription", receiveChannelSuffix: "/default") {
+		}
+	}
+
+	public class AzureMessagingServiceBusQueueTest : MessagingTest, IClassFixture<AzureServiceBusFixture> {
+		public AzureMessagingServiceBusQueueTest(AzureServiceBusFixture fixture) : base(fixture, "q/", "q/fxqueue") {
 		}
 	}
 

--- a/FluentStorage.Tests.Integration/Trio/MessagingTest.cs
+++ b/FluentStorage.Tests.Integration/Trio/MessagingTest.cs
@@ -157,7 +157,7 @@ namespace FluentStorage.Tests.Integration.Messaging {
 			string tag = await SendAsync();
 
 			try {
-				IReadOnlyCollection<QueueMessage> messages = await _msg.ReceiveAsync(_qn);
+				IReadOnlyCollection<IQueueMessage> messages = await _msg.ReceiveAsync(_qn);
 
 				Assert.Contains(messages, m => m.Properties.TryGetValue("tag", out string itag) && itag == tag);
 			}
@@ -176,7 +176,7 @@ namespace FluentStorage.Tests.Integration.Messaging {
 			try {
 				await SendAsync();
 
-				IReadOnlyCollection<QueueMessage> messages = await _msg.PeekAsync(_qn);
+				IReadOnlyCollection<IQueueMessage> messages = await _msg.PeekAsync(_qn);
 
 				Assert.NotEmpty(messages);
 			}

--- a/FluentStorage.Tests/Blobs/VirtualStorageTest.cs
+++ b/FluentStorage.Tests/Blobs/VirtualStorageTest.cs
@@ -21,7 +21,7 @@ namespace FluentStorage.Tests.Blobs {
 
 		[Fact]
 		public async Task Return_files_and_mounts_one_mount() {
-			IReadOnlyCollection<Blob> all = await _vs.ListAsync();
+			IReadOnlyCollection<IBlob> all = await _vs.ListAsync();
 
 			Assert.Equal(1, all.Count);   // "mnt" folder
 			Assert.Equal(new Blob("/mnt", BlobItemKind.Folder), all.First());
@@ -31,7 +31,7 @@ namespace FluentStorage.Tests.Blobs {
 		public async Task Return_files_and_mounts_one_mount_and_one_file() {
 			await _ms0.WriteTextAsync("1.txt", "test");
 
-			IReadOnlyCollection<Blob> all = await _vs.ListAsync();
+			IReadOnlyCollection<IBlob> all = await _vs.ListAsync();
 
 			Assert.Equal(2, all.Count);   // "mnt" folder
 			Assert.Equal(new Blob("/mnt", BlobItemKind.Folder), all.First());

--- a/FluentStorage.Tests/Messaging/LocalDiskMessagingTest.cs
+++ b/FluentStorage.Tests/Messaging/LocalDiskMessagingTest.cs
@@ -104,8 +104,8 @@ namespace FluentStorage.Tests.Messaging {
 			await _sut.SendAsync(channelName, message).ConfigureAwait(false);
 
 			// Assert
-			messageProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.IsAny<IReadOnlyCollection<QueueMessage>>()), Times.Once);
-			messageProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<QueueMessage>>(messages => messages.Count == 1
+			messageProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.IsAny<IReadOnlyCollection<IQueueMessage>>()), Times.Once);
+			messageProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<IQueueMessage>>(messages => messages.Count == 1
 																															   && messages.ElementAt(0).StringContent == message.StringContent)),
 																												   Times.Once);
 
@@ -133,17 +133,17 @@ namespace FluentStorage.Tests.Messaging {
 			await _sut.SendAsync(channelName, message).ConfigureAwait(false);
 
 			// Assert
-			firstProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<QueueMessage>>(messages => messages.Count == 1
+			firstProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<IQueueMessage>>(messages => messages.Count == 1
 																														     && messages.ElementAt(0).StringContent == message.StringContent)),
 																												 Times.Once);
 			firstProcessorMock.VerifyNoOtherCalls();
 
-			secondProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<QueueMessage>>(messages => messages.Count == 1
+			secondProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<IQueueMessage>>(messages => messages.Count == 1
 																														     && messages.ElementAt(0).StringContent == message.StringContent)),
 																												 Times.Once);
 			secondProcessorMock.VerifyNoOtherCalls();
 
-			thirdProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<QueueMessage>>(messages => messages.Count == 1
+			thirdProcessorMock.Verify(mock => mock.ProcessMessagesAsync(It.Is<IReadOnlyCollection<IQueueMessage>>(messages => messages.Count == 1
 																														     && messages.ElementAt(0).StringContent == message.StringContent)),
 																												 Times.Once);
 			thirdProcessorMock.VerifyNoOtherCalls();
@@ -156,16 +156,16 @@ namespace FluentStorage.Tests.Messaging {
 
 	public class StoreEventMessageProcessor : IMessageProcessor {
 
-		public IReadOnlyCollection<QueueMessage> Messages => _messages.ToImmutableArray();
+		public IReadOnlyCollection<IQueueMessage> Messages => _messages.ToImmutableArray();
 
-		private readonly IList<QueueMessage> _messages;
+		private readonly IList<IQueueMessage> _messages;
 
 		public StoreEventMessageProcessor() {
-			_messages = new List<QueueMessage>();
+			_messages = new List<IQueueMessage>();
 		}
 
 		///<inheritdoc/>
-		public Task ProcessMessagesAsync(IReadOnlyCollection<QueueMessage> messages) {
+		public Task ProcessMessagesAsync(IReadOnlyCollection<IQueueMessage> messages) {
 			_messages.AddRange(messages);
 
 			return Task.CompletedTask;

--- a/FluentStorage.sln
+++ b/FluentStorage.sln
@@ -39,6 +39,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentStorage.SFTP", "Fluen
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentStorage.Tests.FTP", "FluentStorage.Tests.FTP\FluentStorage.Tests.FTP.csproj", "{8EC92456-416E-40F0-8126-0D2F89ABD497}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FluentStorage.Azure.Messaging.ServiceBus", "FluentStorage.Azure.Messaging.ServiceBus\FluentStorage.Azure.Messaging.ServiceBus.csproj", "{EC869154-2315-41C4-BDD2-346AE85AC7AC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,10 @@ Global
 		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8EC92456-416E-40F0-8126-0D2F89ABD497}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC869154-2315-41C4-BDD2-346AE85AC7AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC869154-2315-41C4-BDD2-346AE85AC7AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC869154-2315-41C4-BDD2-346AE85AC7AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC869154-2315-41C4-BDD2-346AE85AC7AC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FluentStorage/Blobs/Blob.cs
+++ b/FluentStorage/Blobs/Blob.cs
@@ -8,7 +8,7 @@ namespace FluentStorage.Blobs {
 	/// <summary>
 	/// Blob item description
 	/// </summary>
-	public sealed class Blob : IEquatable<Blob>, ICloneable {
+	public sealed class Blob : IEquatable<Blob>, IBlob {
 		/// <summary>
 		/// Gets the kind of item
 		/// </summary>
@@ -89,7 +89,7 @@ namespace FluentStorage.Blobs {
 		/// </summary>
 		public Dictionary<string, string> Metadata { get; private set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-		internal object Tag { get; set; }
+		public object Tag { get; set; }
 
 		/// <summary>
 		/// Tries to add properties in pairs when value is not null

--- a/FluentStorage/Blobs/BlobStorageExtensions.cs
+++ b/FluentStorage/Blobs/BlobStorageExtensions.cs
@@ -25,10 +25,10 @@ namespace FluentStorage.Blobs {
 		/// <param name="options"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns>List of blob IDs</returns>
-		public static async Task<IReadOnlyCollection<Blob>> ListFilesAsync(this IBlobStorage blobStorage,
+		public static async Task<IReadOnlyCollection<IBlob>> ListFilesAsync(this IBlobStorage blobStorage,
 		   ListOptions options,
 		   CancellationToken cancellationToken = default) {
-			IReadOnlyCollection<Blob> all = await blobStorage.ListAsync(options, cancellationToken).ConfigureAwait(false);
+			IReadOnlyCollection<IBlob> all = await blobStorage.ListAsync(options, cancellationToken).ConfigureAwait(false);
 
 			return all.Where(i => i != null && i.IsFile).ToList();
 		}
@@ -45,9 +45,9 @@ namespace FluentStorage.Blobs {
 		/// <param name="includeAttributes"><see cref="ListOptions.IncludeAttributes"/></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns>List of blob IDs</returns>
-		public static Task<IReadOnlyCollection<Blob>> ListAsync(this IBlobStorage blobStorage,
+		public static Task<IReadOnlyCollection<IBlob>> ListAsync(this IBlobStorage blobStorage,
 		   string folderPath = null,
-		   Func<Blob, bool> browseFilter = null,
+		   Func<IBlob, bool> browseFilter = null,
 		   string filePrefix = null,
 		   bool recurse = false,
 		   int? maxResults = null,
@@ -146,7 +146,7 @@ namespace FluentStorage.Blobs {
 		/// </summary>
 		public static Task DeleteAsync(
 		   this IBlobStorage storage,
-		   IEnumerable<Blob> blobs,
+		   IEnumerable<IBlob> blobs,
 		   CancellationToken cancellationToken = default) {
 			return storage.DeleteAsync(blobs.Select(b => b.FullPath), cancellationToken);
 		}
@@ -155,7 +155,7 @@ namespace FluentStorage.Blobs {
 		/// Gets basic blob metadata
 		/// </summary>
 		/// <returns>Blob metadata or null if blob doesn't exist</returns>
-		public static async Task<Blob> GetBlobAsync(this IBlobStorage storage,
+		public static async Task<IBlob> GetBlobAsync(this IBlobStorage storage,
 		   string fullPath, CancellationToken cancellationToken = default) {
 			return (await storage.GetBlobsAsync(new[] { fullPath }, cancellationToken).ConfigureAwait(false)).First();
 		}
@@ -352,7 +352,7 @@ namespace FluentStorage.Blobs {
 		/// Calculates an MD5 hash of a blob. Comparing to <see cref="Blob.MD5"/> field, it always returns
 		/// a hash, even if the underlying storage doesn't support it natively.
 		/// </summary>
-		public static async Task<string> GetMD5HashAsync(this IBlobStorage blobStorage, Blob blob, CancellationToken cancellationToken = default) {
+		public static async Task<string> GetMD5HashAsync(this IBlobStorage blobStorage, IBlob blob, CancellationToken cancellationToken = default) {
 			if (blob == null)
 				throw new ArgumentNullException(nameof(blob));
 
@@ -434,7 +434,7 @@ namespace FluentStorage.Blobs {
 			else {
 				string fullPath = StoragePath.Combine(folderPath, dummyFileName ?? ".empty");
 
-				// Check if the file already exists before we try to create it to prevent 
+				// Check if the file already exists before we try to create it to prevent
 				// AccessDenied exceptions if two processes are creating the folder at the same time.
 				if (await blobStorage.ExistsAsync(fullPath)) {
 					return;

--- a/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
+++ b/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
@@ -27,15 +27,15 @@ namespace FluentStorage.Blobs.Files {
 		/// <summary>
 		/// Returns the list of blob names in this storage, optionally filtered by prefix
 		/// </summary>
-		public Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
+		public Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			if (options == null) options = new ListOptions();
 
 			GenericValidation.CheckBlobPrefix(options.FilePrefix);
 
-			if (!Directory.Exists(_directoryFullName)) return Task.FromResult<IReadOnlyCollection<Blob>>(new List<Blob>());
+			if (!Directory.Exists(_directoryFullName)) return Task.FromResult<IReadOnlyCollection<IBlob>>(new List<IBlob>());
 
 			string fullPath = GetFolder(options?.FolderPath, false);
-			if (fullPath == null) return Task.FromResult<IReadOnlyCollection<Blob>>(new List<Blob>());
+			if (fullPath == null) return Task.FromResult<IReadOnlyCollection<IBlob>>(new List<IBlob>());
 
 			string[] fileIds = Directory.GetFiles(
 			   fullPath,
@@ -51,7 +51,7 @@ namespace FluentStorage.Blobs.Files {
 					 : options.FilePrefix + "*",
 				  options.Recurse ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
 
-			var result = new List<Blob>();
+			var result = new List<IBlob>();
 			result.AddRange(directoryIds.Select(id => ToBlobItem(id, BlobItemKind.Folder, options.IncludeAttributes)));
 			result.AddRange(
 			   fileIds.Where(fid => !fid.EndsWith(AttributesFileExtension)).Select(id => ToBlobItem(id, BlobItemKind.File, options.IncludeAttributes)));
@@ -59,7 +59,7 @@ namespace FluentStorage.Blobs.Files {
 			   .Where(i => options.BrowseFilter == null || options.BrowseFilter(i))
 			   .Take(options.MaxResults == null ? int.MaxValue : options.MaxResults.Value)
 			   .ToList();
-			return Task.FromResult<IReadOnlyCollection<Blob>>(result);
+			return Task.FromResult<IReadOnlyCollection<IBlob>>(result);
 		}
 
 		private static string FormatFlags(FileAttributes fa) {
@@ -259,8 +259,8 @@ namespace FluentStorage.Blobs.Files {
 		/// <summary>
 		/// See interface
 		/// </summary>
-		public Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
-			var result = new List<Blob>();
+		public Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> ids, CancellationToken cancellationToken = default) {
+			var result = new List<IBlob>();
 
 			foreach (string blobId in ids) {
 				GenericValidation.CheckBlobFullPath(blobId);
@@ -275,10 +275,10 @@ namespace FluentStorage.Blobs.Files {
 				result.Add(ToBlobItem(filePath, BlobItemKind.File, true));
 			}
 
-			return Task.FromResult<IReadOnlyCollection<Blob>>(result);
+			return Task.FromResult<IReadOnlyCollection<IBlob>>(result);
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPaths(blobs);
 
 			foreach (Blob blob in blobs.Where(b => b != null)) {

--- a/FluentStorage/Blobs/Files/ZipFileBlobStorage.cs
+++ b/FluentStorage/Blobs/Files/ZipFileBlobStorage.cs
@@ -50,8 +50,8 @@ namespace FluentStorage.Blobs.Files {
 			return Task.FromResult<IReadOnlyCollection<bool>>(result);
 		}
 
-		public Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
-			var result = new List<Blob>();
+		public Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
+			var result = new List<IBlob>();
 			ZipArchive zipArchive = GetArchive(false);
 
 			foreach (string fullPath in fullPaths) {
@@ -69,23 +69,23 @@ namespace FluentStorage.Blobs.Files {
 				}
 			}
 
-			return Task.FromResult<IReadOnlyCollection<Blob>>(result);
+			return Task.FromResult<IReadOnlyCollection<IBlob>>(result);
 		}
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 
-		public Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options, CancellationToken cancellationToken = default) {
 			if (!File.Exists(_filePath))
-				return Task.FromResult<IReadOnlyCollection<Blob>>(new List<Blob>());
+				return Task.FromResult<IReadOnlyCollection<IBlob>>(new List<IBlob>());
 
 			ZipArchive archive = GetArchive(false);
 
 			if (options == null)
 				options = new ListOptions();
 
-			IEnumerable<Blob> blobs = archive.Entries.Select(ze => new Blob(ze.FullName, BlobItemKind.File));
+			IEnumerable<IBlob> blobs = archive.Entries.Select(ze => new Blob(ze.FullName, BlobItemKind.File));
 
 			if (options.FilePrefix != null)
 				blobs = blobs.Where(id => id.Name.StartsWith(options.FilePrefix));
@@ -114,10 +114,10 @@ namespace FluentStorage.Blobs.Files {
 			if (options.MaxResults != null)
 				blobs = blobs.Take(options.MaxResults.Value);
 
-			return Task.FromResult<IReadOnlyCollection<Blob>>(blobs.ToList());
+			return Task.FromResult<IReadOnlyCollection<IBlob>>(blobs.ToList());
 		}
 
-		private IEnumerable<Blob> AppendVirtualFolders(string rootFolderPath, List<Blob> files) {
+		private IEnumerable<IBlob> AppendVirtualFolders(string rootFolderPath, List<IBlob> files) {
 			var uniqueFolders = new HashSet<string>(
 			   files.Where(f => f.FolderPath != rootFolderPath).Select(f => f.FolderPath));
 

--- a/FluentStorage/Blobs/GenericBlobStorage.cs
+++ b/FluentStorage/Blobs/GenericBlobStorage.cs
@@ -19,8 +19,8 @@ namespace FluentStorage.Blobs {
 		/// <summary>
 		/// Lists blobs
 		/// </summary>
-		public virtual async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
-			var result = new List<Blob>();
+		public virtual async Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
+			var result = new List<IBlob>();
 			if (options == null) options = new ListOptions();
 
 			await ListStepAsync(options.FolderPath, options, result, cancellationToken).ConfigureAwait(false);
@@ -32,8 +32,8 @@ namespace FluentStorage.Blobs {
 			return result;
 		}
 
-		private async Task ListStepAsync(string path, ListOptions options, List<Blob> container, CancellationToken cancellationToken) {
-			IReadOnlyCollection<Blob> chunk = await ListAtAsync(path, options, cancellationToken).ConfigureAwait(false);
+		private async Task ListStepAsync(string path, ListOptions options, List<IBlob> container, CancellationToken cancellationToken) {
+			IReadOnlyCollection<IBlob> chunk = await ListAtAsync(path, options, cancellationToken).ConfigureAwait(false);
 
 			if (options.BrowseFilter != null) {
 				container.AddRange(chunk.Where(b => options.BrowseFilter(b)));
@@ -53,9 +53,9 @@ namespace FluentStorage.Blobs {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
-		protected virtual Task<IReadOnlyCollection<Blob>> ListAtAsync(string path, ListOptions options, CancellationToken cancellationToken) {
+		protected virtual Task<IReadOnlyCollection<IBlob>> ListAtAsync(string path, ListOptions options, CancellationToken cancellationToken) {
 			throw new NotSupportedException();
 		}
 
@@ -74,54 +74,54 @@ namespace FluentStorage.Blobs {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public virtual async Task<IReadOnlyCollection<bool>> ExistsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			return await Task.WhenAll(fullPaths.Select(fp => ExistsAsync(fp, cancellationToken))).ConfigureAwait(false);
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		protected virtual Task<bool> ExistsAsync(string fullPath, CancellationToken cancellationToken) {
 			throw new NotSupportedException();
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
-		public async Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
+		public async Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			return await Task.WhenAll(fullPaths.Select(fp => GetBlobAsync(fp, cancellationToken))).ConfigureAwait(false);
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
-		protected virtual Task<Blob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) => throw new NotSupportedException();
+		protected virtual Task<IBlob> GetBlobAsync(string fullPath, CancellationToken cancellationToken) => throw new NotSupportedException();
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public virtual Task<Stream> OpenReadAsync(string fullPath, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public Task<ITransaction> OpenTransactionAsync() => throw new NotSupportedException();
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public virtual Task WriteAsync(string fullPath, Stream dataStream, bool append = false, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
-		public virtual Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public virtual Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
 		/// <summary>
 		/// Dispose any unused resources

--- a/FluentStorage/Blobs/IBlob.cs
+++ b/FluentStorage/Blobs/IBlob.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace FluentStorage.Blobs;
+
+public interface IBlob : ICloneable
+{
+    /// <summary>
+    /// Gets the kind of item
+    /// </summary>
+    BlobItemKind Kind { get; }
+
+    /// <summary>
+    /// Simply checks if kind of this item is <see cref="BlobItemKind.Folder"/>
+    /// </summary>
+    bool IsFolder { get; }
+
+    /// <summary>
+    /// Simply checks if kind of this item is <see cref="BlobItemKind.File"/>
+    /// </summary>
+    bool IsFile { get; }
+
+    /// <summary>
+    /// Gets the folder path containing this item
+    /// </summary>
+    string FolderPath { get; }
+
+    /// <summary>
+    /// Gets the name of this blob, unique within the folder. In most providers this is the same as file name.
+    /// </summary>
+    string Name { get; }
+
+    /// <summary>
+    /// Blob size
+    /// </summary>
+    long? Size { get; set; }
+
+    /// <summary>
+    /// MD5 content hash of the blob. Note that this property can be null if underlying storage has
+    /// no information about the hash, or it's very expensive to calculate it, for instance it would require
+    /// getting a whole content of the blob to hash it.
+    /// </summary>
+    string MD5 { get; set; }
+
+    /// <summary>
+    /// Creation time when known
+    /// </summary>
+    DateTimeOffset? CreatedTime { get; set; }
+
+    /// <summary>
+    /// Last modification time when known
+    /// </summary>
+    DateTimeOffset? LastModificationTime { get; set; }
+
+    /// <summary>
+    /// Gets full path to this blob which is a combination of folder path and blob name
+    /// </summary>
+    string FullPath { get; }
+
+    /// <summary>
+    /// Custom provider-specific properties. Key names are case-insensitive.
+    /// </summary>
+    Dictionary<string, object> Properties { get; }
+
+    /// <summary>
+    /// Try to get property and cast it to a specified type
+    /// </summary>
+    bool TryGetProperty<TValue>(string name, out TValue value, TValue defaultValue = default);
+
+    /// <summary>
+    /// User defined metadata. Key names are case-insensitive.
+    /// </summary>
+    Dictionary<string, string> Metadata { get; }
+
+    /// <summary>
+    /// Tries to add properties in pairs when value is not null
+    /// </summary>
+    void TryAddProperties(params object[] keyValues);
+
+    /// <summary>
+    /// Works just like <see cref="TryAddProperties(object[])"/> but prefixes all the keys
+    /// </summary>
+    void TryAddPropertiesWithPrefix(string prefix, params object[] keyValues);
+
+    /// <summary>
+    /// Tries to add properties from dictionary by key names
+    /// </summary>
+    void TryAddPropertiesFromDictionary(IDictionary<string, string> source, params string[] keyNames);
+
+    /// <summary>
+    /// Returns true if this item is a folder and it's a root folder
+    /// </summary>
+    bool IsRootFolder { get; }
+
+    /// <summary>
+    /// Full blob info, i.e type, id and path
+    /// </summary>
+    string ToString();
+
+    /// <summary>
+    /// Converts blob attributes (user metadata to byte array)
+    /// </summary>
+    byte[] AttributesToByteArray();
+
+    /// <summary>
+    /// Appends attributes from byte array representation
+    /// </summary>
+    void AppendAttributesFromByteArray(byte[] data);
+
+    /// <summary>
+    /// Prepends path to this blob's path without modifying blob's properties
+    /// </summary>
+    void PrependPath(string path);
+
+    /// <summary>
+    /// Changes full path of this blob without modifying any other property
+    /// </summary>
+    void SetFullPath(string fullPath);
+
+    internal object Tag { get; set; }
+}

--- a/FluentStorage/Blobs/IBlobStorage.cs
+++ b/FluentStorage/Blobs/IBlobStorage.cs
@@ -15,7 +15,7 @@ namespace FluentStorage.Blobs {
 		/// <param name="options"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns>List of blob IDs</returns>
-		Task<IReadOnlyCollection<Blob>> ListAsync(
+		Task<IReadOnlyCollection<IBlob>> ListAsync(
 		   ListOptions options = null,
 		   CancellationToken cancellationToken = default);
 
@@ -63,12 +63,12 @@ namespace FluentStorage.Blobs {
 		/// <summary>
 		/// Gets blob information which is useful for retreiving blob metadata
 		/// </summary>
-		Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default);
+		Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Set blob information which is useful for setting blob attributes (user metadata etc.)
 		/// </summary>
-		Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default);
+		Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Starts a new transaction

--- a/FluentStorage/Blobs/ListOptions.cs
+++ b/FluentStorage/Blobs/ListOptions.cs
@@ -27,7 +27,7 @@ namespace FluentStorage.Blobs {
 		/// Note that filtering will be happening on the client side, therefore this is the least efficient filter and should
 		/// only be used when you're concerned about RAM usage.
 		/// </summary>
-		public Func<Blob, bool> BrowseFilter { get; set; }
+		public Func<IBlob, bool> BrowseFilter { get; set; }
 
 		/// <summary>
 		/// Prefix to filter file name by. Folders are not affected by this filter. If you list files recursively
@@ -61,14 +61,14 @@ namespace FluentStorage.Blobs {
 		/// <summary>
 		/// Helper method that returns true if a <see cref="Blob"/> matches these list options.
 		/// </summary>
-		public bool IsMatch(Blob blob) {
+		public bool IsMatch(IBlob blob) {
 			return _prefix == null || blob.Kind != BlobItemKind.File || blob.Name.StartsWith(_prefix);
 		}
 
 		/// <summary>
 		/// Only for internal use
 		/// </summary>
-		public bool Add(ICollection<Blob> dest, ICollection<Blob> src) {
+		public bool Add(ICollection<IBlob> dest, ICollection<IBlob> src) {
 			if (MaxResults == null || (dest.Count + src.Count < MaxResults.Value)) {
 				dest.AddRange(src);
 				return false;

--- a/FluentStorage/Blobs/Sinks/SinkedBlobStorage.cs
+++ b/FluentStorage/Blobs/Sinks/SinkedBlobStorage.cs
@@ -28,17 +28,17 @@ namespace FluentStorage.Blobs.Sinks {
 			return _parent.ExistsAsync(fullPaths, cancellationToken);
 		}
 
-		public Task<IReadOnlyCollection<Blob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IBlob>> GetBlobsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			return _parent.GetBlobsAsync(fullPaths, cancellationToken);
 		}
 
-		public Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IBlob>> ListAsync(ListOptions options = null, CancellationToken cancellationToken = default) {
 			return _parent.ListAsync(options, cancellationToken);
 		}
 
 		public Task<ITransaction> OpenTransactionAsync() => _parent.OpenTransactionAsync();
 
-		public Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) => _parent.SetBlobsAsync(blobs, cancellationToken);
+		public Task SetBlobsAsync(IEnumerable<IBlob> blobs, CancellationToken cancellationToken = default) => _parent.SetBlobsAsync(blobs, cancellationToken);
 
 		public async Task<Stream> OpenReadAsync(string fullPath, CancellationToken cancellationToken = default) {
 			//chain streams

--- a/FluentStorage/Factory.cs
+++ b/FluentStorage/Factory.cs
@@ -112,14 +112,14 @@ namespace FluentStorage {
 		/// <param name="blobPathGenerator">Optional generator for blob path used to save large message content.</param>
 		/// <returns></returns>
 		public static IMessenger HandleLargeContent(this IMessenger messenger, IBlobStorage offloadStorage, int minSizeLarge,
-		   Func<QueueMessage, string> blobPathGenerator = null) {
+		   Func<IQueueMessage, string> blobPathGenerator = null) {
 			return new LargeMessageMessenger(messenger, offloadStorage, minSizeLarge, blobPathGenerator, false);
 		}
 
 		#region [ Data Decorators ]
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="blobStorage"></param>
 		/// <param name="sinks"></param>
@@ -143,7 +143,7 @@ namespace FluentStorage {
 #if !NET16
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="blobStorage"></param>
 		/// <param name="encryptionKey"></param>
@@ -156,7 +156,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="blobStorage"></param>
 		/// <param name="encryptionKey"></param>
@@ -171,7 +171,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="blobStorage"></param>
 		/// <param name="encryptionKey"></param>
@@ -183,7 +183,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="blobStorage"></param>
 		/// <param name="encryptionKey"></param>

--- a/FluentStorage/FluentStorage.csproj
+++ b/FluentStorage/FluentStorage.csproj
@@ -29,8 +29,7 @@
       <DefineConstants>JSON</DefineConstants>
    </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
       <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
       <PackageReference Include="System.Text.Json" Version="7.0.3" />
    </ItemGroup>

--- a/FluentStorage/GenericValidation.cs
+++ b/FluentStorage/GenericValidation.cs
@@ -50,7 +50,7 @@ namespace FluentStorage {
 		/// <summary>
 		/// Checks blob full path for generic rules
 		/// </summary>
-		public static void CheckBlobFullPaths(IEnumerable<Blob> blobs) {
+		public static void CheckBlobFullPaths(IEnumerable<IBlob> blobs) {
 			if (blobs == null)
 				return;
 

--- a/FluentStorage/Messaging/Files/LocalDiskMessenger.cs
+++ b/FluentStorage/Messaging/Files/LocalDiskMessenger.cs
@@ -103,7 +103,7 @@ namespace FluentStorage.Messaging.Files {
 			return Task.FromResult<long>(GetMessageFiles(channelName).Count);
 		}
 
-		public Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
@@ -122,7 +122,7 @@ namespace FluentStorage.Messaging.Files {
 			return Task.FromResult(true);
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName,
 		   int count = 100,
 		   TimeSpan? visibility = null,
@@ -130,7 +130,7 @@ namespace FluentStorage.Messaging.Files {
 			return Task.FromResult(GetMessages(channelName, count));
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			return Task.FromResult(GetMessages(channelName, count));
 		}
 
@@ -145,11 +145,11 @@ namespace FluentStorage.Messaging.Files {
 #endif
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
 		#endregion
 
-		private IReadOnlyCollection<QueueMessage> GetMessages(
+		private IReadOnlyCollection<IQueueMessage> GetMessages(
 		   string channelName,
 		   int count) {
 			//get all files (not efficient, but we hope there won't be many)

--- a/FluentStorage/Messaging/IMessageProcessor.cs
+++ b/FluentStorage/Messaging/IMessageProcessor.cs
@@ -9,10 +9,10 @@ namespace FluentStorage.Messaging {
 	/// </summary>
 	public interface IMessageProcessor {
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="messages"></param>
 		/// <returns></returns>
-		Task ProcessMessagesAsync(IReadOnlyCollection<QueueMessage> messages);
+		Task ProcessMessagesAsync(IReadOnlyCollection<IQueueMessage> messages);
 	}
 }

--- a/FluentStorage/Messaging/IMessageReceiver.cs
+++ b/FluentStorage/Messaging/IMessageReceiver.cs
@@ -22,12 +22,12 @@ namespace FluentStorage.Messaging {
 		/// </summary>
 		/// <param name="messages"></param>
 		/// <param name="cancellationToken"></param>
-		Task ConfirmMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default);
+		Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Moves the message to a dead letter queue
 		/// </summary>
-		Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default);
+		Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Peeks messages from the queue, without changing their visibility or removing from the queue.
@@ -36,13 +36,13 @@ namespace FluentStorage.Messaging {
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		/// <exception cref="NotSupportedException">Thrown when peeking is not supported by the current provider</exception>
-		Task<IReadOnlyCollection<QueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default);
+		Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Starts automatic message pumping trying to use native features as much as possible. Message pump stops when you dispose the instance.
 		/// Disposing the instance will also stop message pump for you.
 		/// </summary>
-		Task StartMessagePumpAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default);
+		Task StartMessagePumpAsync(Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Notifies the backend that processing is still happening and message should be marked alive.
@@ -51,7 +51,7 @@ namespace FluentStorage.Messaging {
 		/// <param name="timeToLive">Optional time-to-live</param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task KeepAliveAsync(QueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default);
+		Task KeepAliveAsync(IQueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Starts a new transaction

--- a/FluentStorage/Messaging/IMessenger.cs
+++ b/FluentStorage/Messaging/IMessenger.cs
@@ -46,7 +46,7 @@ namespace FluentStorage.Messaging {
 		/// <param name="messages"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default);
+		Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// Receive messages from a channel
@@ -56,7 +56,7 @@ namespace FluentStorage.Messaging {
 		/// <param name="visibility"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName,
 		   int count = 100,
 		   TimeSpan? visibility = null,
@@ -69,7 +69,7 @@ namespace FluentStorage.Messaging {
 		/// <param name="count"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		Task<IReadOnlyCollection<QueueMessage>> PeekAsync(
+		Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(
 		   string channelName,
 		   int count = 100,
 		   CancellationToken cancellationToken = default);
@@ -83,7 +83,7 @@ namespace FluentStorage.Messaging {
 		/// <returns></returns>
 		Task DeleteAsync(
 		   string channelName,
-		   IEnumerable<QueueMessage> messages,
+		   IEnumerable<IQueueMessage> messages,
 		   CancellationToken cancellationToken = default);
 
 		/// <summary>

--- a/FluentStorage/Messaging/IQueueMessage.cs
+++ b/FluentStorage/Messaging/IQueueMessage.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FluentStorage.Messaging;
+
+public interface IQueueMessage {
+		/// Message ID
+		/// </summary>
+		public string Id { get; set; }
+
+		/// <summary>
+		/// Gets the count of how many time this message was dequeued
+		/// </summary>
+		public int DequeueCount { get; set; }
+
+		/// <summary>
+		/// When present, indicates time when this message becomes visible again
+		/// </summary>
+		public DateTimeOffset? NextVisibleTime { get; set; }
+
+		/// <summary>
+		/// Message content as string
+		/// </summary>
+		public string StringContent { get; set; }
+
+		/// <summary>
+		/// Message content as byte array
+		/// </summary>
+		public byte[] Content { get; set; }
+
+		/// <summary>
+		/// Extra properties for this message
+		/// </summary>
+		public Dictionary<string, string> Properties { get; }
+
+		/// <summary>
+		/// Clones the message
+		/// </summary>
+		/// <returns></returns>
+		public QueueMessage Clone();
+
+		/// <summary>
+		/// Extremely compact binary representation of the message.
+		/// It's library specific, therefore try not to use it if portability is required.
+		/// </summary>
+		/// <returns></returns>
+		public byte[] ToByteArray();
+	}

--- a/FluentStorage/Messaging/InMemoryMessenger.cs
+++ b/FluentStorage/Messaging/InMemoryMessenger.cs
@@ -10,14 +10,14 @@ namespace FluentStorage.Messaging {
 		private static readonly ConcurrentDictionary<string, InMemoryMessenger> _nameToMessenger =
 		   new ConcurrentDictionary<string, InMemoryMessenger>();
 
-		private readonly ConcurrentDictionary<string, ConcurrentQueue<QueueMessage>> _queues =
-		   new ConcurrentDictionary<string, ConcurrentQueue<QueueMessage>>();
+		private readonly ConcurrentDictionary<string, ConcurrentQueue<IQueueMessage>> _queues =
+		   new ConcurrentDictionary<string, ConcurrentQueue<IQueueMessage>>();
 
 		#region [ IMessenger ]
 
 		public Task CreateChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) {
 			foreach (string channelName in channelNames) {
-				_queues[channelName] = new ConcurrentQueue<QueueMessage>();
+				_queues[channelName] = new ConcurrentQueue<IQueueMessage>();
 			}
 
 			return Task.CompletedTask;
@@ -27,7 +27,7 @@ namespace FluentStorage.Messaging {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
-			ConcurrentQueue<QueueMessage> queue = GetQueue(channelName);
+			ConcurrentQueue<IQueueMessage> queue = GetQueue(channelName);
 			return Task.FromResult((long)queue.Count);
 		}
 
@@ -40,36 +40,36 @@ namespace FluentStorage.Messaging {
 				throw new ArgumentNullException(nameof(channelNames));
 
 			foreach (string cn in channelNames) {
-				_queues.TryRemove(cn, out ConcurrentQueue<QueueMessage> v);
+				_queues.TryRemove(cn, out ConcurrentQueue<IQueueMessage> v);
 			}
 
 			return Task.CompletedTask;
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
-			return Task.FromResult<IReadOnlyCollection<QueueMessage>>(GetMessages(channelName, count, true, null));
+			return Task.FromResult<IReadOnlyCollection<IQueueMessage>>(GetMessages(channelName, count, true, null));
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(
 		   string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
-			return Task.FromResult<IReadOnlyCollection<QueueMessage>>(GetMessages(channelName, count, false, visibility));
+			return Task.FromResult<IReadOnlyCollection<IQueueMessage>>(GetMessages(channelName, count, false, visibility));
 		}
 
-		private List<QueueMessage> GetMessages(string channelName, int count, bool peekOnly, TimeSpan? visibility) {
-			var result = new List<QueueMessage>();
-			ConcurrentQueue<QueueMessage> queue = GetQueue(channelName);
+		private List<IQueueMessage> GetMessages(string channelName, int count, bool peekOnly, TimeSpan? visibility) {
+			var result = new List<IQueueMessage>();
+			ConcurrentQueue<IQueueMessage> queue = GetQueue(channelName);
 
 			DateTime now = DateTime.UtcNow;
 			DateTimeOffset nextVisible = now + (visibility ?? TimeSpan.FromMinutes(1));
 
 			while (result.Count < count) {
-				if (!queue.TryDequeue(out QueueMessage msg))
+				if (!queue.TryDequeue(out IQueueMessage msg))
 					break;
 
 				bool isVisible = msg.NextVisibleTime == null || (msg.NextVisibleTime.Value >= now);
@@ -92,14 +92,14 @@ namespace FluentStorage.Messaging {
 
 		}
 
-		public Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			if (channelName is null)
 				throw new ArgumentNullException(nameof(channelName));
 
 			if (messages is null)
 				throw new ArgumentNullException(nameof(messages));
 
-			ConcurrentQueue<QueueMessage> queue = GetQueue(channelName);
+			ConcurrentQueue<IQueueMessage> queue = GetQueue(channelName);
 			foreach (QueueMessage qm in messages) {
 				queue.Enqueue(qm);
 			}
@@ -113,8 +113,8 @@ namespace FluentStorage.Messaging {
 
 		#endregion
 
-		private ConcurrentQueue<QueueMessage> GetQueue(string channelName) {
-			return _queues.GetOrAdd(channelName, new ConcurrentQueue<QueueMessage>());
+		private ConcurrentQueue<IQueueMessage> GetQueue(string channelName) {
+			return _queues.GetOrAdd(channelName, new ConcurrentQueue<IQueueMessage>());
 		}
 
 		public static IMessenger CreateOrGet(string name) {
@@ -126,7 +126,7 @@ namespace FluentStorage.Messaging {
 			return messenger;
 		}
 
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 	}
 }

--- a/FluentStorage/Messaging/Large/LargeMessageContentMessageReceiver.cs
+++ b/FluentStorage/Messaging/Large/LargeMessageContentMessageReceiver.cs
@@ -14,21 +14,21 @@ namespace FluentStorage.Messaging.Large {
 			_offloadStorage = offloadStorage;
 		}
 
-		public async Task ConfirmMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			await _parentReceiver.ConfirmMessagesAsync(messages, cancellationToken).ConfigureAwait(false);
 
-			foreach (QueueMessage message in messages) {
+			foreach (IQueueMessage message in messages) {
 				await DeleteBlobAsync(message).ConfigureAwait(false);
 			}
 		}
 
-		public async Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
+		public async Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {
 			await _parentReceiver.DeadLetterAsync(message, reason, errorDescription, cancellationToken).ConfigureAwait(false);
 
 			await DeleteBlobAsync(message).ConfigureAwait(false);
 		}
 
-		private async Task DeleteBlobAsync(QueueMessage message) {
+		private async Task DeleteBlobAsync(IQueueMessage message) {
 			if (!message.Properties.TryGetValue(QueueMessage.LargeMessageContentHeaderName, out string fileId)) return;
 
 			message.Properties.Remove(QueueMessage.LargeMessageContentHeaderName);
@@ -44,17 +44,17 @@ namespace FluentStorage.Messaging.Large {
 
 		public Task<ITransaction> OpenTransactionAsync() => _parentReceiver.OpenTransactionAsync();
 
-		public Task StartMessagePumpAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default) {
+		public Task StartMessagePumpAsync(Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default) {
 			return _parentReceiver.StartMessagePumpAsync(
 			   (mms, ct) => DownloadingMessagePumpAsync(mms, onMessageAsync, ct),
 			   maxBatchSize, cancellationToken);
 		}
 
-		private async Task DownloadingMessagePumpAsync(IReadOnlyCollection<QueueMessage> messages,
-		   Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onParentMessagesAsync,
+		private async Task DownloadingMessagePumpAsync(IReadOnlyCollection<IQueueMessage> messages,
+		   Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onParentMessagesAsync,
 		   CancellationToken cancellationToken) {
 			//process messages to download external content
-			foreach (QueueMessage message in messages) {
+			foreach (IQueueMessage message in messages) {
 				if (!message.Properties.TryGetValue(QueueMessage.LargeMessageContentHeaderName, out string fileId)) continue;
 
 				message.Content = await _offloadStorage.ReadBytesAsync(fileId, cancellationToken).ConfigureAwait(false);
@@ -64,8 +64,8 @@ namespace FluentStorage.Messaging.Large {
 			await onParentMessagesAsync(messages, cancellationToken).ConfigureAwait(false);
 		}
 
-		public Task KeepAliveAsync(QueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) =>
+		public Task KeepAliveAsync(IQueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) =>
 		   _parentReceiver.KeepAliveAsync(message, timeToLive, cancellationToken);
-		public Task<IReadOnlyCollection<QueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 	}
 }

--- a/FluentStorage/Messaging/Large/LargeMessageMessenger.cs
+++ b/FluentStorage/Messaging/Large/LargeMessageMessenger.cs
@@ -11,13 +11,13 @@ namespace FluentStorage.Messaging.Large {
 		private readonly IBlobStorage _offloadStorage;
 		private readonly long _minSizeLarge;
 		private readonly bool _keepPublisherOpen;
-		private readonly Func<QueueMessage, string> _blobPathGenerator;
+		private readonly Func<IQueueMessage, string> _blobPathGenerator;
 
 		public LargeMessageMessenger(
 		   IMessenger parentPublisher,
 		   IBlobStorage offloadStorage,
 		   long minSizeLarge,
-		   Func<QueueMessage, string> blobPathGenerator = null,
+		   Func<IQueueMessage, string> blobPathGenerator = null,
 		   bool keepPublisherOpen = false) {
 			_parentPublisher = parentPublisher ?? throw new ArgumentNullException(nameof(parentPublisher));
 			_offloadStorage = offloadStorage ?? throw new ArgumentNullException(nameof(offloadStorage));
@@ -26,17 +26,17 @@ namespace FluentStorage.Messaging.Large {
 			_keepPublisherOpen = keepPublisherOpen;
 		}
 
-		private void AddBlobId(QueueMessage message, out string id) {
+		private void AddBlobId(IQueueMessage message, out string id) {
 			id = _blobPathGenerator(message);
 
 			message.Properties[QueueMessage.LargeMessageContentHeaderName] = id;
 		}
 
-		private string GenerateBlobPath(QueueMessage message) {
+		private string GenerateBlobPath(IQueueMessage message) {
 			return StoragePath.Combine("message", Guid.NewGuid().ToString());
 		}
 
-		private async Task SendAsync(string channelName, QueueMessage message, CancellationToken cancellationToken) {
+		private async Task SendAsync(string channelName, IQueueMessage message, CancellationToken cancellationToken) {
 			if (message?.Content.Length > _minSizeLarge) {
 				AddBlobId(message, out string id);
 
@@ -53,12 +53,12 @@ namespace FluentStorage.Messaging.Large {
 
 		public Task<IReadOnlyCollection<string>> ListChannelsAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task<long> GetMessageCountAsync(string channelName, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public async Task SendAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) {
+		public async Task SendAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) {
 			await Task.WhenAll(messages.Select(m => SendAsync(channelName, m, cancellationToken))).ConfigureAwait(false);
 		}
 
-		public Task<IReadOnlyCollection<QueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task<IReadOnlyCollection<QueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> ReceiveAsync(string channelName, int count = 100, TimeSpan? visibility = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task<IReadOnlyCollection<IQueueMessage>> PeekAsync(string channelName, int count = 100, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 
 		public void Dispose() {
 			if (!_keepPublisherOpen) {
@@ -68,7 +68,7 @@ namespace FluentStorage.Messaging.Large {
 
 		public Task DeleteChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task CreateChannelsAsync(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) => throw new NotImplementedException();
-		public Task DeleteAsync(string channelName, IEnumerable<QueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+		public Task DeleteAsync(string channelName, IEnumerable<IQueueMessage> messages, CancellationToken cancellationToken = default) => throw new NotImplementedException();
 		public Task StartMessageProcessorAsync(string channelName, IMessageProcessor messageProcessor) => throw new NotImplementedException();
 
 		#endregion

--- a/FluentStorage/Messaging/PollingMessageReceiver.cs
+++ b/FluentStorage/Messaging/PollingMessageReceiver.cs
@@ -26,12 +26,12 @@ namespace FluentStorage.Messaging {
 		/// <summary>
 		/// See interface
 		/// </summary>
-		public abstract Task ConfirmMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default);
+		public abstract Task ConfirmMessagesAsync(IReadOnlyCollection<IQueueMessage> messages, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// See interface
 		/// </summary>
-		public abstract Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default);
+		public abstract Task DeadLetterAsync(IQueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default);
 
 		/// <summary>
 		/// See interface
@@ -50,7 +50,7 @@ namespace FluentStorage.Messaging {
 		/// <summary>
 		/// See interface
 		/// </summary>
-		public Task StartMessagePumpAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default)
+		public Task StartMessagePumpAsync(Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default)
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 		{
 			if (onMessageAsync == null) throw new ArgumentNullException(nameof(onMessageAsync));
@@ -60,9 +60,9 @@ namespace FluentStorage.Messaging {
 			return Task.FromResult(true);
 		}
 
-		private async Task PollTasksAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> callback, int maxBatchSize, CancellationToken cancellationToken) {
+		private async Task PollTasksAsync(Func<IReadOnlyCollection<IQueueMessage>, CancellationToken, Task> callback, int maxBatchSize, CancellationToken cancellationToken) {
 			try {
-				IReadOnlyCollection<QueueMessage> messages = await ReceiveMessagesSafeAsync(maxBatchSize, cancellationToken).ConfigureAwait(false);
+				IReadOnlyCollection<IQueueMessage> messages = await ReceiveMessagesSafeAsync(maxBatchSize, cancellationToken).ConfigureAwait(false);
 				while (messages != null && messages.Count > 0) {
 					await callback(messages, cancellationToken).ConfigureAwait(false);
 
@@ -84,9 +84,9 @@ namespace FluentStorage.Messaging {
 			}
 		}
 
-		private async Task<IReadOnlyCollection<QueueMessage>> ReceiveMessagesSafeAsync(int maxBatchSize, CancellationToken cancellationToken) {
+		private async Task<IReadOnlyCollection<IQueueMessage>> ReceiveMessagesSafeAsync(int maxBatchSize, CancellationToken cancellationToken) {
 			try {
-				IReadOnlyCollection<QueueMessage> messages = await ReceiveMessagesAsync(maxBatchSize, cancellationToken).ConfigureAwait(false);
+				IReadOnlyCollection<IQueueMessage> messages = await ReceiveMessagesAsync(maxBatchSize, cancellationToken).ConfigureAwait(false);
 
 				return messages;
 			}
@@ -103,12 +103,12 @@ namespace FluentStorage.Messaging {
 		/// <summary>
 		/// See interface
 		/// </summary>
-		protected abstract Task<IReadOnlyCollection<QueueMessage>> ReceiveMessagesAsync(int maxBatchSize, CancellationToken cancellationToken);
+		protected abstract Task<IReadOnlyCollection<IQueueMessage>> ReceiveMessagesAsync(int maxBatchSize, CancellationToken cancellationToken);
 
 		/// <summary>
 		/// See interface
 		/// </summary>
-		public Task KeepAliveAsync(QueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
+		public Task KeepAliveAsync(IQueueMessage message, TimeSpan? timeToLive = null, CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
 		/// <summary>
 		/// see interface
@@ -116,7 +116,7 @@ namespace FluentStorage.Messaging {
 		/// <param name="maxMessages"></param>
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
-		public virtual Task<IReadOnlyCollection<QueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) {
+		public virtual Task<IReadOnlyCollection<IQueueMessage>> PeekMessagesAsync(int maxMessages, CancellationToken cancellationToken = default) {
 			throw new NotSupportedException();
 		}
 	}

--- a/FluentStorage/Messaging/QueueMessage.cs
+++ b/FluentStorage/Messaging/QueueMessage.cs
@@ -7,7 +7,7 @@ namespace FluentStorage.Messaging {
 	/// <summary>
 	/// Message to be used in all the queueing code
 	/// </summary>
-	public class QueueMessage {
+	public class QueueMessage : IQueueMessage {
 		/// <summary>
 		/// Message header that points to large message content, if you are using content offloading feature
 		/// </summary>


### PR DESCRIPTION
The main project `FluentStorage` is referencing `Newtonsoft.Json` without using it.

To me, its better to not take such dependency in the main project, so  we can reference it in our main application layer without taking external dependencies, and then reference to desired implementation in our infrastructure project. Then if the implementation needs Newstonsoft.Json, we take the dependency here.

Also i would like to take a step further and create an abstraction project (`FluentStorage.Abstractions`), wich contains all the public interfaces.

So we can reference this in our application project, then bind the desired implementation with dependency injection in the infrastructure.

If you are good with this idea i can prepare another PR, otherwise i'll implement the interfaces only in my project :)