### PR TITLE
Remove Newtonsoft.Json from FluentStorage project (supersedes #43)

### DIFF
--- a/FluentStorage/FluentStorage.csproj
+++ b/FluentStorage/FluentStorage.csproj
@@ -30,7 +30,6 @@
    </PropertyGroup>
    <ItemGroup>
       <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
       <PackageReference Include="System.Text.Json" Version="7.0.3" />
    </ItemGroup>


### PR DESCRIPTION
This PR resumes the old #43 where i made a mess with GIT :)

> The main project FluentStorage is referencing Newtonsoft.Json without using it.
> 
> To me, its better to not take such dependency in the main project, so we can reference it in our main application layer without taking external dependencies, and then reference to desired implementation in our infrastructure project. Then if the implementation needs Newstonsoft.Json, we take the dependency here.

