### PR TITLE
Make Disk WriteAsync also use CopyToAsync

### DIFF
--- a/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
+++ b/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
@@ -191,18 +191,15 @@ namespace FluentStorage.Blobs.Files {
 		public void Dispose() {
 		}
 
-		public Task WriteAsync(string fullPath, Stream dataStream, bool append, CancellationToken cancellationToken) {
+		public async Task WriteAsync(string fullPath, Stream dataStream, bool append, CancellationToken cancellationToken) {
 			if (dataStream is null)
 				throw new ArgumentNullException(nameof(dataStream));
 			GenericValidation.CheckBlobFullPath(fullPath);
 
 			fullPath = StoragePath.Normalize(fullPath);
 
-			using (Stream stream = CreateStream(fullPath, !append)) {
-				dataStream.CopyTo(stream);
-			}
-
-			return Task.FromResult(true);
+			using Stream stream = CreateStream(fullPath, !append);
+			await dataStream.CopyToAsync(stream);
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Fixes

```
System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Microsoft.AspNetCore.WebUtilities.BufferedReadStream.EnsureBuffered(Int32 minCount)
   at Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at System.IO.Stream.CopyTo(Stream destination, Int32 bufferSize)
   at FluentStorage.Blobs.Files.DiskDirectoryBlobStorage.WriteAsync(String fullPath, Stream dataStream, Boolean append, CancellationToken cancellationToken)
```

### Note
I also think this fix is the correct way to handle this. Reading synchronously in a async method does not seem like the right way to do it if async is available, and it is available here.