### PR TITLE
Added recursion for FluentStorage.FTP

### DIFF
--- a/FluentStorage.FTP/FluentFtpBlobStorage.cs
+++ b/FluentStorage.FTP/FluentFtpBlobStorage.cs
@@ -48,7 +48,14 @@ namespace FluentStorage.FTP {
 			if (options == null)
 				options = new ListOptions();
 
-			FtpListItem[] items = await client.GetListing(options.FolderPath).ConfigureAwait(false);
+			FtpListOption ftpListOption = FtpListOption.Auto;
+
+			if (options.Recurse)
+			{
+				ftpListOption |= FtpListOption.Recursive;
+			}
+
+			FtpListItem[] items = await client.GetListing(options.FolderPath, ftpListOption, cancellationToken).ConfigureAwait(false);
 
 			List<Blob> results = new List<Blob>();
 			foreach (FtpListItem item in items) {


### PR DESCRIPTION
### Fixes
Issue #53

### Description
Uses `FtpListOption.Recursive` to enable recursion for listing directories. 

This also adds cancellationToken being passed through to the FTP client so listing can be cancelled.

I have not run any of the tests to confirm these changes work, but this is copy/pasted where I am using it for an internal tool I am testing out.