### PR TITLE
Recursive list directory for FluentStorage.SFTP

### DIFF
--- a/FluentStorage.SFTP/FluentStorage.SFTP.csproj
+++ b/FluentStorage.SFTP/FluentStorage.SFTP.csproj
@@ -23,8 +23,7 @@
 
    <ItemGroup>
      <PackageReference Include="Polly" Version="7.2.4" />
-    <PackageReference Include="Renci.SshNet.Async" Version="1.4.0" />
-    <PackageReference Include="SSH.NET" Version="2020.0.2" />
+    <PackageReference Include="SSH.NET" Version="2023.0.1" />
    </ItemGroup>
 
    <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
+++ b/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
@@ -35,7 +35,7 @@ namespace FluentStorage.SFTP {
 		/// <summary>
 		/// Object used in in ListDirectoryAsync to avoid accessing collections from multiple threads at the same time.
 		/// </summary>
-		private object listDirectoryLockObject = new object();
+		private readonly object _listDirectoryLockObject = new object();
 
 		/// <summary>
 		/// Gets or sets the maximum retry count.
@@ -324,7 +324,7 @@ namespace FluentStorage.SFTP {
 #if NET6_0_OR_GREATER
 				await Parallel.ForEachAsync(subFoldersToList, async (subFolder, token) => {
 					var tempForEachBlobCollection = await ListDirectoryAsync(client, subFolder, options, cancellationToken);
-					lock (listDirectoryLockObject) {
+					lock (_listDirectoryLockObject) {
 						blobCollection.AddRange(tempForEachBlobCollection);
 					}
 				});


### PR DESCRIPTION
### Fixes

Issue #55 

### Description

Not sure the preferred way to handle this. I created a local function so I could share the lock object rather than adding it as a class variable. If you are using .NET 6+ it allows the use of `Parallel.ForEachAsync`. Because of using `Parallel.ForEachAsync` I also added a lock for updating the main list. Unsure if there are complications of allowing this to query a server multiple times at once (also with no upper bound set).

I am also unsure if this should be littered with `.ConfigureAwait(false)` for all those tasks it is using.

I have not run any of the tests to confirm these changes work, but this is copy/pasted where I am using it for an internal tool I am testing out.