### PR TITLE
Set length of destination stream manually to avoid resulting data bei…

### DIFF
--- a/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
+++ b/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
@@ -369,13 +369,16 @@ namespace FluentStorage.SFTP {
 
 			SftpClient client = GetClient();
 			var fullPathWithRoot = StoragePath.Combine(RootDirectory, StoragePath.Normalize(fullPath));
+			var fileMode = append ? FileMode.Append : FileMode.OpenOrCreate;
 
 			// First, for speed, let's try to write the file assuming the directory requested already exists.
 
 			try {
-				using (Stream dest = client.OpenWrite(fullPathWithRoot)) {
+				using (Stream dest = client.Open(fullPathWithRoot, fileMode, FileAccess.Write)) {
 					await dataStream.CopyToAsync(dest).ConfigureAwait(false);
-					dest.SetLength(dataStream.Length);
+					if (append == false) {
+						dest.SetLength(dataStream.Length);
+					}
 				}
 				return;
 			}
@@ -396,9 +399,11 @@ namespace FluentStorage.SFTP {
 						client.CreateDirectory(fullFolder);
 				}
 
-				using (Stream dest = client.OpenWrite(fullPathWithRoot)) {
+				using (Stream dest = client.Open(fullPathWithRoot, fileMode, FileAccess.Write)) {
 					await dataStream.CopyToAsync(dest).ConfigureAwait(false);
-					dest.SetLength(dataStream.Length);
+					if (append == false) {
+						dest.SetLength(dataStream.Length);
+					}
 				}
 			}).ConfigureAwait(false);
 		}

--- a/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
+++ b/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
@@ -375,6 +375,7 @@ namespace FluentStorage.SFTP {
 			try {
 				using (Stream dest = client.OpenWrite(fullPathWithRoot)) {
 					await dataStream.CopyToAsync(dest).ConfigureAwait(false);
+					dest.SetLength(dataStream.Length);
 				}
 				return;
 			}
@@ -397,6 +398,7 @@ namespace FluentStorage.SFTP {
 
 				using (Stream dest = client.OpenWrite(fullPathWithRoot)) {
 					await dataStream.CopyToAsync(dest).ConfigureAwait(false);
+					dest.SetLength(dataStream.Length);
 				}
 			}).ConfigureAwait(false);
 		}


### PR DESCRIPTION
…ng left

### Fixes

Issue #52
Issue #58 

### Description

For issue 52,
This PR fixes the issue here, but it may be preferred to fix the issue in SSH.NET itself.

For issue 58,
Adjusting the way we open the file allows us to append data. Doing so we also need to exclude the usage of `dest.SetLength(` as it would truncate the destination file to the length of the source file.

Considering this I now wonder if there are situations when `dataStream.Length` may not exist or be accurate. Should this code check that `dataStream.Length` > 0 before it attempts to set the length? Not doing so could cause the entire file to be wiped out.