### PR TITLE
Fix for issue #21 - serviceURl  in connection string

### DIFF
--- a/FluentStorage.AWS/AwsStorageModule.cs
+++ b/FluentStorage.AWS/AwsStorageModule.cs
@@ -10,9 +10,11 @@ namespace FluentStorage.AWS {
 
 		public IBlobStorage CreateBlobStorage(StorageConnectionString connectionString) {
 			if (connectionString.Prefix == KnownPrefix.AwsS3) {
+
+				string region = String.Empty;
+				
 				string cliProfileName = connectionString.Get(KnownParameter.LocalProfileName);
 				connectionString.GetRequired(KnownParameter.BucketName, true, out string bucket);
-				connectionString.GetRequired(KnownParameter.Region, true, out string region);
 
 				if (string.IsNullOrEmpty(cliProfileName)) {
 					string keyId = connectionString.Get(KnownParameter.KeyId);
@@ -21,14 +23,30 @@ namespace FluentStorage.AWS {
 					if (string.IsNullOrEmpty(keyId) != string.IsNullOrEmpty(key)) {
 						throw new ArgumentException($"connection string requires both 'key' and 'keyId' parameters, or neither.");
 					}
-
-
+					
 					if (string.IsNullOrEmpty(keyId)) {
+						connectionString.GetRequired(KnownParameter.Region, true, out region);
+
 						return new AwsS3BlobStorage(bucket, region);
 					}
 
+					// get region and/or serviceUrl options from connection string ...
+					
+					var serviceUrl = connectionString.Get(KnownParameter.ServiceUrl);
+					region = connectionString.Get(KnownParameter.Region);
+
+					// only one or the other is allowed simultaneously, so throw if both are specified
+					
+					if (!String.IsNullOrWhiteSpace(serviceUrl) && !String.IsNullOrWhiteSpace(region)) {
+						throw new ArgumentException($"connection string can have either 'region' or 'serviceUrl' parameters, but not both.");
+						
+					}
+					
 					string sessionToken = connectionString.Get(KnownParameter.SessionToken);
-					return new AwsS3BlobStorage(keyId, key, sessionToken, bucket, region, null);
+
+					// pass serviceUrl in to blob storage constructor as well as region - previous guard clause ensures that only one will ever be non-NULL
+					
+					return new AwsS3BlobStorage(keyId, key, sessionToken, bucket, region, serviceUrl);
 				}
 #if !NET16
 				else {

--- a/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
@@ -139,7 +139,10 @@ namespace FluentStorage.AWS.Blobs {
 			}
 
 			if (options.IncludeAttributes) {
-				foreach (IEnumerable<Blob> page in blobs.Where(b => !b.IsFolder).Chunk(ListChunkSize)) {
+
+				// added null check here to avoid intermittent exceptions when querying for metadata
+				
+				foreach (IEnumerable<Blob> page in blobs.Where(b => b != null && !b.IsFolder).Chunk(ListChunkSize)) {
 					await Converter.AppendMetadataAsync(client, _bucketName, page, cancellationToken).ConfigureAwait(false);
 				}
 			}

--- a/FluentStorage/KnownParameter.cs
+++ b/FluentStorage/KnownParameter.cs
@@ -46,6 +46,11 @@ namespace FluentStorage {
 		public static readonly string Region = "region";
 
 		/// <summary>
+		/// Service URL
+		/// </summary>
+		public static readonly string ServiceUrl = "serviceUrl";
+		
+		/// <summary>
 		/// 
 		/// </summary>
 		public static readonly string UseDevelopmentStorage = "development";


### PR DESCRIPTION
### Fixes

Issue #21 - what about MinIO?

### Description

Adds support for specifying a `serviceUrl` parameter in the Aws.S3 connection string.  Sanity check included to ensure `region` and `serviceUrl` are not specified together.  New `KnownParameter` enum created for `serviceUrl`

Additional check added in `AwsS3BlobStorage.cs` to prevent an intermittent exception when querying S3 metadata
