### PR TITLE
Feature/minio connection string prefix

### DIFF
--- a/FluentStorage.AWS/AwsStorageModule.cs
+++ b/FluentStorage.AWS/AwsStorageModule.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Amazon.SQS.Model;
 using FluentStorage.AWS.Blobs;
 using FluentStorage.Blobs;
 using FluentStorage.ConnectionString;

--- a/FluentStorage/KnownPrefix.cs
+++ b/FluentStorage/KnownPrefix.cs
@@ -9,6 +9,11 @@
 		public static string AwsS3 = "aws.s3";
 
 		/// <summary>
+		/// Amazon S3
+		/// </summary>
+		public static string MinIoS3 = "minio.s3";
+		
+		/// <summary>
 		/// Databricks on Azure or AWS
 		/// </summary>
 		public static string Databricks = "databricks";


### PR DESCRIPTION
### Description

Adds new connection string prefix 'minio.s3' to allow MinIO connections to be created using only a connection string

When the new `KnownPrefix.MinIoS3` value is passed to `FluentStorage.Aws.CreatyeBlobStorage(StorageConnectionString)`, the convenience method `AwsS3BlobStorage.FromMinIO()` is used instead of the main constructor.  This method always sets `ForcePathStyle` to TRUE, which is required for some MinIO functionality (e.g. presigned URL support)
