### PR TITLE
Allow directory recursion to happen on S3/MinIO (rather than locally)

### DIFF
--- a/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
@@ -24,7 +24,7 @@ namespace FluentStorage.AWS.Blobs {
 		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			var container = new List<Blob>();
 
-			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads);
+			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads ?? 10);
 			
 			await ListFolderAsync(container, options.FolderPath, options, cancellationToken).ConfigureAwait(false);
 

--- a/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
@@ -14,7 +14,7 @@ namespace FluentStorage.AWS.Blobs {
 	class AwsS3DirectoryBrowser : IDisposable {
 		private readonly AmazonS3Client _client;
 		private readonly string _bucketName;
-		private readonly AsyncLimiter _limiter = new AsyncLimiter(10);
+		private AsyncLimiter _limiter;
 
 		public AwsS3DirectoryBrowser(AmazonS3Client client, string bucketName) {
 			_client = client;
@@ -24,6 +24,8 @@ namespace FluentStorage.AWS.Blobs {
 		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			var container = new List<Blob>();
 
+			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads);
+			
 			await ListFolderAsync(container, options.FolderPath, options, cancellationToken).ConfigureAwait(false);
 
 			return options.MaxResults == null
@@ -37,7 +39,7 @@ namespace FluentStorage.AWS.Blobs {
 			var request = new ListObjectsV2Request() {
 				BucketName = _bucketName,
 				Prefix = FormatFolderPrefix(path),
-				Delimiter = "/"   //this tells S3 not to go into the folder recursively
+				Delimiter = options.Recurse ? null : "/"   //this tells S3 not to go into the folder recursively
 			};
 
 			// Server side filtering is supported by supplying a FilePrefix			
@@ -64,7 +66,7 @@ namespace FluentStorage.AWS.Blobs {
 
 			container.AddRange(folderContainer);
 
-			if (options.Recurse) {
+			if (options.Recurse && options.RecursionMode == RecursionMode.Local) {
 				List<Blob> folders = folderContainer.Where(b => b.Kind == BlobItemKind.Folder).ToList();
 
 				await Task.WhenAll(folders.Select(f => ListFolderAsync(container, f.FullPath, options, cancellationToken))).ConfigureAwait(false);
@@ -104,7 +106,7 @@ namespace FluentStorage.AWS.Blobs {
 		}
 
 		public void Dispose() {
-			_limiter.Dispose();
+			_limiter?.Dispose();
 		}
 	}
 }

--- a/FluentStorage.FTP/FluentStorage.FTP.csproj
+++ b/FluentStorage.FTP/FluentStorage.FTP.csproj
@@ -23,6 +23,7 @@
 
    <ItemGroup>
       <PackageReference Include="FluentFTP" Version="44.0.1" />
+      <PackageReference Include="Polly" Version="8.4.0" />
    </ItemGroup>
 
    <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/FluentStorage/Blobs/BlobStorageExtensions.cs
+++ b/FluentStorage/Blobs/BlobStorageExtensions.cs
@@ -41,6 +41,8 @@ namespace FluentStorage.Blobs {
 		/// <param name="browseFilter"><see cref="ListOptions.BrowseFilter"/></param>
 		/// <param name="filePrefix"><see cref="ListOptions.FilePrefix"/></param>
 		/// <param name="recurse"><see cref="ListOptions.Recurse"/></param>
+		/// <param name="recursionMode"><see cref="ListOptions.RecursionMode"/></param>
+		/// <param name="numberOfRecursionThreads"><see cref="ListOptions.NumberOfRecursionThreads"/></param>
 		/// <param name="maxResults"><see cref="ListOptions.MaxResults"/></param>
 		/// <param name="includeAttributes"><see cref="ListOptions.IncludeAttributes"/></param>
 		/// <param name="cancellationToken"></param>
@@ -50,6 +52,8 @@ namespace FluentStorage.Blobs {
 		   Func<Blob, bool> browseFilter = null,
 		   string filePrefix = null,
 		   bool recurse = false,
+		   RecursionMode recursionMode = RecursionMode.Local,
+		   int numberOfRecursionThreads = 10,
 		   int? maxResults = null,
 		   bool includeAttributes = false,
 		   CancellationToken cancellationToken = default) {
@@ -61,6 +65,8 @@ namespace FluentStorage.Blobs {
 			if (filePrefix != null)
 				options.FilePrefix = filePrefix;
 			options.Recurse = recurse;
+			options.RecursionMode = recursionMode;
+			options.NumberOfRecursionThreads = numberOfRecursionThreads;
 			if (maxResults != null)
 				options.MaxResults = maxResults;
 			options.IncludeAttributes = includeAttributes;

--- a/FluentStorage/Blobs/ListOptions.cs
+++ b/FluentStorage/Blobs/ListOptions.cs
@@ -4,6 +4,22 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace FluentStorage.Blobs {
+
+	/// <summary>
+	/// Controls recursion mode
+	/// </summary>
+	public enum RecursionMode {
+		/// <summary>
+		/// Recurse locally - for each folder on the remote datastore, iterate and query in a separate task
+		/// </summary>
+		Local = 1,
+
+		/// <summary>
+		/// Recurse remotely - let the remote datastore return the entire folder tree
+		/// </summary>
+		Remote
+	}
+	
 	/// <summary>
 	/// Options for listing storage content
 	/// </summary>
@@ -46,6 +62,16 @@ namespace FluentStorage.Blobs {
 		/// </summary>
 		public bool Recurse { get; set; }
 
+		/// <summary>
+		/// Recursion mode to use if recusion is enabled
+		/// </summary>
+		public RecursionMode RecursionMode { get; set; } = RecursionMode.Local;
+
+		/// <summary>
+		/// If recursing locally, specify the number of parallel tasks to use when querying
+		/// </summary>
+		public int NumberOfRecursionThreads { get; set; } = 10;
+		
 		/// <summary>
 		/// When set, limits the maximum amount of results. The count affects all object counts, including files and folders.
 		/// </summary>

--- a/FluentStorage/Blobs/ListOptions.cs
+++ b/FluentStorage/Blobs/ListOptions.cs
@@ -70,7 +70,7 @@ namespace FluentStorage.Blobs {
 		/// <summary>
 		/// If recursing locally, specify the number of parallel tasks to use when querying
 		/// </summary>
-		public int NumberOfRecursionThreads { get; set; } = 10;
+		public int? NumberOfRecursionThreads { get; set; }
 		
 		/// <summary>
 		/// When set, limits the maximum amount of results. The count affects all object counts, including files and folders.


### PR DESCRIPTION
### Description

When recursing into multiple subdirectories on a locally-hosted MinIO server, I have experienced a lot of unreliability in terms of the number of files reported by `ListFolderAsync()`.  After some investigation, I determined that there was an issue in the local recursion code, although I have not been able to identify the exact cause.  The problem seems to be here:

```await Task.WhenAll(folders.Select(f => ListFolderAsync(container, f.FullPath, options, cancellationToken))).ConfigureAwait(false);```

If I change this to:

```
foreach(var folder in folders)
{
    await ListFolderAsync(container, folder.FullPath, options, cancellationToken).ConfigureAwait(false)
}
```
or simply change the `AsyncLimiter` value from `10` down to `1`, everything works reliably (but much more slowly!)

But there is also an option to have the recursion done on the S3 server itself.  In this case it just returns all the files names to the client using the `NextContinuationToken` mechanism.  In my tests, this also works reliably, and no more slowly than the local recursion method.

So, this PR adds additional properties to the `ListOptions` class, to allow the user to specify local or remote recursion, and also to control the number of parallel tasks used for local recursion.  The defaults remain as before.

--- UPDATE ---

Attached is a minimal reproduction solution.  Usage:

```
minio-repro <bucket name> <api key> <secret key> <s3 key> (<serviceUrl> | <region>)

<s3 key> is the s3 key of a folder inside the bucket containing test data
```

The code will query the folder 10 times in succession using `Storage.ListFilesAsync()` with recursion enabled and report the number of files returned on each query.  In my testing, with a bucket containing 320 files spread across multiple folders I get this:

```
d:\projects\minio-repro>minio-repro <bucket name> <api key> <secret key> <s3 key> <minio server url>
Attempt #1 ... files: 317
Attempt #2 ... files: 319
Attempt #3 ... files: 316
Attempt #4 ... files: 319
Attempt #5 ... files: 319
Attempt #6 ... files: 318
Attempt #7 ... files: 319
Attempt #8 ... files: 319
Attempt #9 ... files: 318
Attempt #10 ... files: 314
```

[minio-repro.zip](https://github.com/user-attachments/files/16071251/minio-repro.zip)

