### PR TITLE
fixing the prefixed \ in ZipFileBlobStorage paths

### DIFF
--- a/FluentStorage.FTP/FluentStorage.FTP.csproj
+++ b/FluentStorage.FTP/FluentStorage.FTP.csproj
@@ -23,6 +23,7 @@
 
    <ItemGroup>
       <PackageReference Include="FluentFTP" Version="44.0.1" />
+      <PackageReference Include="Polly" Version="8.4.0" />
    </ItemGroup>
 
    <PropertyGroup Condition="'$(Configuration)' == 'Release'">

--- a/FluentStorage.Tests.Console/FluentStorage.Tests.Console.csproj
+++ b/FluentStorage.Tests.Console/FluentStorage.Tests.Console.csproj
@@ -6,6 +6,8 @@
   </PropertyGroup>
 
    <ItemGroup>
+       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+       
      <ProjectReference Include="..\FluentStorage.AWS\FluentStorage.AWS.csproj" />
      <ProjectReference Include="..\FluentStorage.Azure.EventHub\FluentStorage.Azure.EventHub.csproj" />
      <ProjectReference Include="..\FluentStorage.Tests.Integration\FluentStorage.Tests.Integration.csproj" />

--- a/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
+++ b/FluentStorage.Tests.Integration/FluentStorage.Tests.Integration.csproj
@@ -6,6 +6,7 @@
    </PropertyGroup>
 
    <ItemGroup>
+       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
       <PackageReference Include="xunit" Version="2.5.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
          <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Fixes ZipFileBlobStorage puts "\\" in front of entry

Issue #69
Issue #39

### Description
ZipFileBlobStorage no longer puts a "\\" as prefix in zipfile paths.
also fixed FTP project (missing Polly nuget) and running tests (missing Microsoft.NET.Test.Sdk nuget)
