### PR TITLE
Pass bucket name in IAwsS3BlobStorage

### DIFF
--- a/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
@@ -36,6 +36,10 @@ namespace FluentStorage.AWS.Blobs {
 
 		//https://github.com/awslabs/aws-sdk-net-samples/blob/master/ConsoleSamples/AmazonS3Sample/AmazonS3Sample/S3Sample.cs
 
+		/// <summary>
+		/// Return bucket name.
+		/// </summary>
+		public string BucketName => _bucketName;
 
 #if !NET16
 		public static AwsS3BlobStorage FromAwsCliProfile(string profileName, string bucketName, string region) {

--- a/FluentStorage.AWS/Blobs/IAwsS3BlobStorage.cs
+++ b/FluentStorage.AWS/Blobs/IAwsS3BlobStorage.cs
@@ -13,6 +13,11 @@ namespace FluentStorage.AWS.Blobs {
 		IAmazonS3 NativeBlobClient { get; }
 
 		/// <summary>
+		/// Return bucket name.
+		/// </summary>
+		string BucketName { get; }
+
+		/// <summary>
 		/// Get presigned url for upload object to Blob Storage.
 		/// </summary>
 		Task<string> GetUploadUrlAsync(string fullPath, string mimeType, int expiresInSeconds = 86000);


### PR DESCRIPTION
### Description

To fully utilize IAwsS3BlobStorage:NativeBlobClient, you also need to obtain the bucket name from somewhere. This MR introduces a method that returns the bucket name.
