### PR TITLE
Feature/default remote recursion

### DIFF
--- a/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
@@ -24,7 +24,7 @@ namespace FluentStorage.AWS.Blobs {
 		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			var container = new List<Blob>();
 
-			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads ?? 10);
+			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads ?? ListOptions.MAX_THREADS);
 			
 			await ListFolderAsync(container, options.FolderPath, options, cancellationToken).ConfigureAwait(false);
 
@@ -37,6 +37,7 @@ namespace FluentStorage.AWS.Blobs {
 
 		private async Task ListFolderAsync(List<Blob> container, string path, ListOptions options, CancellationToken cancellationToken) {
 			var request = new ListObjectsV2Request() {
+				MaxKeys = options.PageSize ?? 1000,
 				BucketName = _bucketName,
 				Prefix = FormatFolderPrefix(path),
 				Delimiter = options.Recurse ? null : "/"   //this tells S3 not to go into the folder recursively

--- a/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3DirectoryBrowser.cs
@@ -24,7 +24,7 @@ namespace FluentStorage.AWS.Blobs {
 		public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken) {
 			var container = new List<Blob>();
 
-			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads ?? 10);
+			_limiter = new AsyncLimiter(options.NumberOfRecursionThreads ?? ListOptions.MAX_THREADS);
 			
 			await ListFolderAsync(container, options.FolderPath, options, cancellationToken).ConfigureAwait(false);
 
@@ -37,6 +37,7 @@ namespace FluentStorage.AWS.Blobs {
 
 		private async Task ListFolderAsync(List<Blob> container, string path, ListOptions options, CancellationToken cancellationToken) {
 			var request = new ListObjectsV2Request() {
+				MaxKeys = options.PageSize ?? ListOptions.PAGE_SIZE,
 				BucketName = _bucketName,
 				Prefix = FormatFolderPrefix(path),
 				Delimiter = options.Recurse ? null : "/"   //this tells S3 not to go into the folder recursively

--- a/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
@@ -22,7 +22,7 @@ namespace FluentStorage.Azure.Blobs {
 
 
 	class AzureBlobStorage : IAzureBlobStorage {
-		private const int BrowserParallelism = 10;
+		
 		private readonly BlobServiceClient _client;
 		private readonly StorageSharedKeyCredential _sasSigningCredentials;
 		private readonly string _containerName;
@@ -382,7 +382,7 @@ namespace FluentStorage.Azure.Blobs {
 		   List<Blob> result,
 		   ListOptions options,
 		   CancellationToken cancellationToken) {
-			using (var browser = new AzureContainerBrowser(container, _containerName == null, BrowserParallelism)) {
+			using (var browser = new AzureContainerBrowser(container, _containerName == null, options.NumberOfRecursionThreads ?? ListOptions.MAX_THREADS)) {
 				IReadOnlyCollection<Blob> containerBlobs =
 				   await browser.ListFolderAsync(options, cancellationToken)
 					  .ConfigureAwait(false);

--- a/FluentStorage.GCP/Blobs/GoogleCloudStorageBlobStorage.cs
+++ b/FluentStorage.GCP/Blobs/GoogleCloudStorageBlobStorage.cs
@@ -32,7 +32,8 @@ namespace FluentStorage.Gcp.CloudStorage.Blobs {
 			ObjectsResource.ListRequest request = _client.Service.Objects.List(_bucketName);
 			request.Prefix = StoragePath.IsRootPath(path) ? null : (NormalisePath(path) + "/");
 			request.Delimiter = "/";
-
+			request.MaxResults = options.PageSize ?? 1000;
+			
 			var page = new List<Blob>();
 			do {
 				Objects serviceObjects = await request.ExecuteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/FluentStorage.GCP/Blobs/GoogleCloudStorageBlobStorage.cs
+++ b/FluentStorage.GCP/Blobs/GoogleCloudStorageBlobStorage.cs
@@ -32,7 +32,8 @@ namespace FluentStorage.Gcp.CloudStorage.Blobs {
 			ObjectsResource.ListRequest request = _client.Service.Objects.List(_bucketName);
 			request.Prefix = StoragePath.IsRootPath(path) ? null : (NormalisePath(path) + "/");
 			request.Delimiter = "/";
-
+			request.MaxResults = options.PageSize ?? ListOptions.PAGE_SIZE;
+			
 			var page = new List<Blob>();
 			do {
 				Objects serviceObjects = await request.ExecuteAsync(cancellationToken: cancellationToken).ConfigureAwait(false);

--- a/FluentStorage/Blobs/BlobStorageExtensions.cs
+++ b/FluentStorage/Blobs/BlobStorageExtensions.cs
@@ -52,8 +52,8 @@ namespace FluentStorage.Blobs {
 		   Func<Blob, bool> browseFilter = null,
 		   string filePrefix = null,
 		   bool recurse = false,
-		   RecursionMode recursionMode = RecursionMode.Local,
-		   int numberOfRecursionThreads = 10,
+		   RecursionMode recursionMode = RecursionMode.Remote,
+		   int numberOfRecursionThreads = ListOptions.MAX_THREADS,
 		   int? maxResults = null,
 		   bool includeAttributes = false,
 		   CancellationToken cancellationToken = default) {

--- a/FluentStorage/Blobs/ListOptions.cs
+++ b/FluentStorage/Blobs/ListOptions.cs
@@ -24,6 +24,10 @@ namespace FluentStorage.Blobs {
 	/// Options for listing storage content
 	/// </summary>
 	public class ListOptions {
+
+		public const int MAX_THREADS = 10;
+		public const int PAGE_SIZE = 1000;
+		
 		private string _prefix;
 		private string _folderPath = StoragePath.RootFolderPath;
 
@@ -63,14 +67,25 @@ namespace FluentStorage.Blobs {
 		public bool Recurse { get; set; }
 
 		/// <summary>
-		/// Recursion mode to use if recusion is enabled
+		/// Recursion mode to use if recursion is enabled.  Remote recursion is the default for services which support it.
+		///
+		///  * AWS/MinIO     : Allows remote or local recursion
+		///  * Azure/GCP/FTP : recursion always occurs remotely regardless of this setting
+		///  * SFTP/Disk/ZIP : recursion always occurs locally regardless of this setting
 		/// </summary>
-		public RecursionMode RecursionMode { get; set; } = RecursionMode.Local;
+		public RecursionMode RecursionMode { get; set; } = RecursionMode.Remote;
 
 		/// <summary>
-		/// If recursing locally, specify the number of parallel tasks to use when querying
+		/// Specify the number of parallel tasks to use when querying (default 10)
+		/// This option is only relevant for S3/MinIO and Azure
 		/// </summary>
 		public int? NumberOfRecursionThreads { get; set; }
+
+		/// <summary>
+		/// When recursing, specify the number of items returned per page from the remote service (default 1000)
+		/// This option is only relevant for S3/MinIO and GCP
+		/// </summary>
+		public int? PageSize { get; set; }
 		
 		/// <summary>
 		/// When set, limits the maximum amount of results. The count affects all object counts, including files and folders.


### PR DESCRIPTION
### Fixes

Request from Robin to make remote recursion the default where supported.

### Description

This PR changes the default value of `ListOptions.RecursionMode` from `Local` to `Remote`.  This ensures that S3/MinIO connections will recurse remotely unless otherwise specified.  `Azure` / `GCP` and `FTP` connections always recurse remotely, regardless of this setting, and `SFTP` / `Disk` and `ZIP` connections always recurse locally.

It also adds a new `PAGE_SIZE` parameter to `ListOptions` which can be used to control the internal paging size used for remote recursion on S3/MinIO and GCP connections

Also, the default values for `ListOptions.NumberOfRecursionThreads` and the new `ListOptions.PageSize` properties are now specified using  public constants defined in `ListOptions`, rather than being scattered throughout the code as before!