### PR TITLE
#79 - added IAzureBlobStorage.OpenWriteAsync(...)

### DIFF
--- a/FluentStorage.Azure.Blobs/IAzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/IAzureBlobStorage.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentStorage.Blobs;
@@ -92,6 +93,15 @@ namespace FluentStorage.Azure.Blobs {
 		   bool includeUrl = true,
 		   CancellationToken cancellationToken = default);
 
+		/// <summary>
+		/// Opens a stream for writing to the blob. If the blob exists, it will be overwritten.
+		/// </summary>
+		/// <param name="fullPath"></param>
+		/// <param name="cancellationToken"></param>
+		/// <returns></returns>
+		Task<Stream> OpenWriteAsync(
+			string fullPath,
+			CancellationToken cancellationToken = default);
 
 	}
 }


### PR DESCRIPTION
### Fixes

Issue #79 

### Description

I added a detailed description in the issue #79 any my reason to extend the `IAzureBlobStorage` interface.
I really tried to stick with the `IBlobStorage.WriteAsync` method, but appending block blobs just does not work with Azure :-|
