### PR TITLE
Update FluentStorage to Microsoft.IO.RecyclableMemoryStream 3.0.1

### DIFF
--- a/FluentStorage/Blobs/Sinks/SinkedStream.cs
+++ b/FluentStorage/Blobs/Sinks/SinkedStream.cs
@@ -1,24 +1,19 @@
-﻿using System;
+﻿using Microsoft.IO;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.IO;
 
 namespace FluentStorage.Blobs.Sinks {
 	class SinkedStream : Stream {
 		private readonly Stream _parentReadStream;
-		private readonly string _fullBlobPath;
-		private readonly ITransformSink[] _transformSinks;
 		private static readonly RecyclableMemoryStreamManager _streamManager = new RecyclableMemoryStreamManager();
-		private readonly MemoryStream _ms;
+		private readonly RecyclableMemoryStream _ms;
 
 		public SinkedStream(Stream parentReadStream, string fullBlobPath, params ITransformSink[] transformSinks) {
 			_parentReadStream = parentReadStream ?? throw new ArgumentNullException(nameof(parentReadStream));
-			_fullBlobPath = fullBlobPath ?? throw new ArgumentNullException(nameof(fullBlobPath));
-			_transformSinks = transformSinks ?? throw new ArgumentNullException(nameof(transformSinks));
+			_ = fullBlobPath ?? throw new ArgumentNullException(nameof(fullBlobPath));
+			_ = transformSinks ?? throw new ArgumentNullException(nameof(transformSinks));
 			if (!_parentReadStream.CanRead)
 				throw new ArgumentException("stream is not readable", nameof(parentReadStream));
 
@@ -47,8 +42,8 @@ namespace FluentStorage.Blobs.Sinks {
 		public override void SetLength(long value) => throw new NotSupportedException();
 		public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
 
-		private static MemoryStream TransformToMemoryStream(string fullPath, Stream parentReadStream, ITransformSink[] sinks) {
-			MemoryStream ms = _streamManager.GetStream();
+		private static RecyclableMemoryStream TransformToMemoryStream(string fullPath, Stream parentReadStream, ITransformSink[] sinks) {
+			RecyclableMemoryStream ms = _streamManager.GetStream();
 
 			try {
 				//layer sinks and move data to memory stream

--- a/FluentStorage/FluentStorage.csproj
+++ b/FluentStorage/FluentStorage.csproj
@@ -29,7 +29,7 @@
       <DefineConstants>JSON</DefineConstants>
    </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.3.2" />
+      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
       <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
       <PackageReference Include="System.Text.Json" Version="7.0.3" />
    </ItemGroup>


### PR DESCRIPTION
### Fixes
The breaking change in Microsoft.IO.RecyclableMemoryStream  which now returns a RecyclableMemoryStream instead of a stream

Issue #84 

### Description
Updated the SinkedStream to return a RecyclableMemoryStream in place of a MemoryStream stopping the error being thrown.  The class inherits from MemoryStream so the code works without any further changes