### PR TITLE
Added ability to set the text content when writing dummy files

### DIFF
--- a/FluentStorage/Blobs/BlobStorageExtensions.cs
+++ b/FluentStorage/Blobs/BlobStorageExtensions.cs
@@ -433,7 +433,7 @@ namespace FluentStorage.Blobs {
 		/// <param name="cancellationToken"></param>
 		/// <returns></returns>
 		public static async Task CreateFolderAsync(
-		   this IBlobStorage blobStorage, string folderPath, string dummyFileName = null, CancellationToken cancellationToken = default) {
+		   this IBlobStorage blobStorage, string folderPath, string dummyFileName = null, string dummyFileContent = null, CancellationToken cancellationToken = default) {
 			if (blobStorage is IHierarchicalBlobStorage hierarchicalBlobStorage) {
 				await hierarchicalBlobStorage.CreateFolderAsync(folderPath, cancellationToken).ConfigureAwait(false);
 			}
@@ -448,7 +448,7 @@ namespace FluentStorage.Blobs {
 
 				await blobStorage.WriteTextAsync(
 				   fullPath,
-				   "created as a workaround by FluentStorage when creating an empty parent folder",
+				   dummyFileContent ?? "created as a workaround by FluentStorage when creating an empty parent folder",
 				   null,
 				   cancellationToken).ConfigureAwait(false);
 			}


### PR DESCRIPTION
### Description

When creating folders FluentStorage may create a dummy file to ensure the folder is visible (e.g. S3).  This change allows the content of the dummy file to be changed from the default text "created as a workaround by FluentStorage when creating an empty parent folder""


