### PR TITLE
Enhanced AzureBlobStorageWithSas with BlobClientOptions

### DIFF
--- a/FluentStorage.Azure.Blobs/Factory.cs
+++ b/FluentStorage.Azure.Blobs/Factory.cs
@@ -35,7 +35,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public static IAzureBlobStorage AzureBlobStorageWithSharedKey(this IBlobStorageFactory factory,
 		   string accountName,
@@ -54,7 +54,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public static IAzureDataLakeStorage AzureDataLakeStorageWithSharedKey(this IBlobStorageFactory factory,
 		   string accountName,
@@ -157,7 +157,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public static IAzureBlobStorage AzureBlobStorageWithTokenCredential(this IBlobStorageFactory factory,
 		   string accountName,
@@ -168,16 +168,17 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		/// <param name="factory"></param>
 		/// <param name="sas"></param>
+		/// <param name="options"></param>
 		/// <returns></returns>
 		public static IAzureBlobStorage AzureBlobStorageWithSas(this IBlobStorageFactory factory,
-		   string sas) {
+		   string sas, BlobClientOptions options = default) {
 			TryParseSasUrl(sas, out string accountName, out string containerName, out string sasQuery);
 
-			var client = new BlobServiceClient(new Uri(sas));
+			var client = new BlobServiceClient(new Uri(sas), options);
 
 			return new AzureBlobStorage(client, accountName, containerName: containerName);
 		}
@@ -257,7 +258,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public static StorageConnectionString ForAzureBlobStorageWithAzureAd(this IConnectionStringFactory factory,
 		   string accountName,
@@ -273,7 +274,7 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
-		/// 
+		///
 		/// </summary>
 		public static StorageConnectionString ForAzureDataLakeStorageWithAzureAd(this IConnectionStringFactory factory,
 		   string accountName,


### PR DESCRIPTION
### Description
When using the Exists method, the internal library will try to retrieve the blob and all the errors will be cached and false will be returned as in the blob does not exist.

AzureBLobStorage.cs
``` 
private async Task<bool> ExistsAsync(string fullPath, CancellationToken cancellationToken = default (CancellationToken))
    {
      (BlobContainerClient client, string blobName) = await this.GetPartsAsync(fullPath).ConfigureAwait(false);
      if (client == null)
        return false;
      BlobBaseClient blobBaseClient = client.GetBlobBaseClient(blobName);
      try
      {
        Response<BlobProperties> response = await blobBaseClient.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
      }
      catch (RequestFailedException ex) when (ex.ErrorCode == "BlobNotFound")
      {
        return false;
      }
      return true;
    }
```

Internally, it does a HEAD http call which returns 404. As this implementation is fine, monitoring tools like datadog and application insights will receive false negatives (404 errors will be reported). More info: https://github.com/Azure/azure-sdk-for-net/issues/20882

One way to fix this is by disabling the IsLoggingEnabled which is part of the BlobClientOptions. This was describe in this issue: https://github.com/Azure/azure-sdk-for-net/issues/19982#issuecomment-812537407
```var options = new BlobClientOptions
{
    Diagnostics =
    {
        IsLoggingEnabled = false
    }
}```

However, the fluentstorage library does not allow configuring the BlobClientOptions. This PR solves this problem.