### PR TITLE
feat: update OpenReadAsync to use OpenReadAsync from Azure SDK

### DIFF
--- a/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
@@ -1,31 +1,25 @@
-﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure;
+﻿using Azure;
 using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
-using Azure.Storage.Sas;
-using Blobs;
-using Microsoft.Identity.Client;
 using FluentStorage.Blobs;
-using FluentStorage.Azure.Blobs.Gen2.Model;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace FluentStorage.Azure.Blobs {
 	//auth scenarios: https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/storage/Azure.Storage.Blobs/samples/Sample02_Auth.cs
 
-
-	class AzureBlobStorage : IAzureBlobStorage {
-
+	internal class AzureBlobStorage : IAzureBlobStorage {
 		private readonly BlobServiceClient _client;
 		private readonly StorageSharedKeyCredential _sasSigningCredentials;
 		private readonly string _containerName;
+
 		private readonly ConcurrentDictionary<string, BlobContainerClient> _containerNameToContainerClient =
 		   new ConcurrentDictionary<string, BlobContainerClient>();
 
@@ -37,7 +31,6 @@ namespace FluentStorage.Azure.Blobs {
 			_client = blobServiceClient ?? throw new ArgumentNullException(nameof(blobServiceClient));
 			_sasSigningCredentials = sasSigningCredentials;
 			_containerName = containerName;
-
 		}
 
 		#region [ Interface Methods ]
@@ -75,14 +68,14 @@ namespace FluentStorage.Azure.Blobs {
 			return result;
 		}
 
-
 		public async Task DeleteAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPaths(fullPaths);
 
 			await Task.WhenAll(fullPaths.Select(fullPath => DeleteAsync(fullPath, cancellationToken))).ConfigureAwait(false);
 		}
 
-		public void Dispose() { }
+		public void Dispose() {
+		}
 
 		public async Task<IReadOnlyCollection<bool>> ExistsAsync(IEnumerable<string> fullPaths, CancellationToken cancellationToken = default) {
 			return await Task.WhenAll(fullPaths.Select(p => ExistsAsync(p, cancellationToken))).ConfigureAwait(false);
@@ -92,7 +85,6 @@ namespace FluentStorage.Azure.Blobs {
 			return await Task.WhenAll(fullPaths.Select(p => GetBlobAsync(p, cancellationToken))).ConfigureAwait(false);
 		}
 
-
 		public async Task<Stream> OpenReadAsync(string fullPath, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPath(fullPath);
 
@@ -101,14 +93,15 @@ namespace FluentStorage.Azure.Blobs {
 			BlockBlobClient client = container.GetBlockBlobClient(path);
 
 			try {
-				//current SDK fails to download 0-sized files
-				Response<BlobProperties> p = await client.GetPropertiesAsync().ConfigureAwait(false);
-				if (p.Value.ContentLength == 0)
+				// Backward compatibility: Explicitly handle empty blobs to ensure they return a MemoryStream,
+				// preserving the behavior of the old implementation.
+				var properties = await client.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+				if (properties.Value.ContentLength == 0) {
 					return new MemoryStream();
+				}
 
-				Response<BlobDownloadInfo> response = await client.DownloadAsync(cancellationToken).ConfigureAwait(false);
-
-				return response.Value.Content;
+				return await client.OpenReadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 			}
 			catch (RequestFailedException ex) when (ex.ErrorCode == "BlobNotFound") {
 				return null;
@@ -137,13 +130,14 @@ namespace FluentStorage.Azure.Blobs {
 				//happens when trying to write to a non-file object i.e. folder
 			}
 		}
+
 		public async Task SetBlobsAsync(IEnumerable<Blob> blobs, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPaths(blobs);
 
 			await Task.WhenAll(blobs.Select(b => SetBlobAsync(b, cancellationToken))).ConfigureAwait(false);
 		}
 
-		#endregion
+		#endregion [ Interface Methods ]
 
 		#region [ IAzureBlobStorage Specific ]
 
@@ -307,7 +301,6 @@ namespace FluentStorage.Azure.Blobs {
 		public async Task<Stream> OpenWriteAsync(string fullPath, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPath(fullPath);
 
-
 			(BlobContainerClient container, string path) = await GetPartsAsync(fullPath, true).ConfigureAwait(false);
 
 			BlockBlobClient client = container.GetBlockBlobClient(path);
@@ -322,8 +315,7 @@ namespace FluentStorage.Azure.Blobs {
 			return null;
 		}
 
-		#endregion
-
+		#endregion [ IAzureBlobStorage Specific ]
 
 		private async Task SetBlobAsync(Blob blob, CancellationToken cancellationToken) {
 			if (!(await ExistsAsync(blob, cancellationToken).ConfigureAwait(false)))
@@ -369,7 +361,6 @@ namespace FluentStorage.Azure.Blobs {
 			}
 		}
 
-
 		private async Task<IReadOnlyCollection<BlobContainerClient>> ListContainersAsync(CancellationToken cancellationToken) {
 			var r = new List<BlobContainerClient>();
 
@@ -390,7 +381,6 @@ namespace FluentStorage.Azure.Blobs {
 				r.Add(logsContainerClient);
 			}
 			catch (RequestFailedException ex) when (ex.ErrorCode == "ContainerNotFound") {
-
 			}
 
 			return r;
@@ -419,7 +409,6 @@ namespace FluentStorage.Azure.Blobs {
 				await container.DeleteIfExistsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 			}
 			else {
-
 				BlockBlobClient blob = string.IsNullOrEmpty(path)
 				   ? null
 				   : container.GetBlockBlobClient(StoragePath.Normalize(path));
@@ -491,7 +480,6 @@ namespace FluentStorage.Azure.Blobs {
 					try {
 						//check if container exists
 						await container.GetPropertiesAsync().ConfigureAwait(false);
-
 					}
 					catch (RequestFailedException ex) when (ex.ErrorCode == "ContainerNotFound") {
 						if (createContainer) {

--- a/FluentStorage.Tests.Integration/Trio/BlobTest.cs
+++ b/FluentStorage.Tests.Integration/Trio/BlobTest.cs
@@ -9,8 +9,11 @@ using FluentStorage.Tests.Integration.Util;
 using Xunit;
 using FluentStorage.Utils.Extensions;
 using FluentStorage.Utils.Generator;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 
 namespace FluentStorage.Tests.Integration.Blobs {
+
 	[Trait("Category", "Blobs")]
 	public abstract class BlobTest : IAsyncLifetime {
 		private readonly IBlobStorage _storage;
@@ -105,7 +108,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 				IReadOnlyCollection<Blob> items = await _storage.ListAsync(recurse: true, folderPath: folderPath);
 				Assert.Equal(4, items.Count); //1.txt + sub (folder) + 2.txt + 3.txt
-
 			}
 			catch (NotSupportedException) {
 				//it ok for providers not to support hierarchy
@@ -169,7 +171,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				BrowseFilter = id => (id.Kind != BlobItemKind.File || id.FullPath == id1)
 			});
 
-
 			Assert.Single(files);
 			Assert.Equal(id1, files.First().FullPath);
 		}
@@ -202,7 +203,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 
 				IReadOnlyCollection<Blob> subItems = await _storage.ListAsync(recurse: false, folderPath: sub);
 				Assert.Equal(2, subItems.Count);
-
 
 				Assert.Contains(new Blob(sub + "one.txt"), subItems);
 				Assert.Contains(new Blob(sub + "sub", BlobItemKind.Folder), subItems);
@@ -259,16 +259,41 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				Blob rb = await _storage.GetBlobAsync(root);
 			}
 			catch (NotSupportedException) {
-
 			}
 		}
-
 
 		[Fact]
 		public async Task Open_doesnt_exist_returns_null() {
 			string id = RandomBlobPath();
 
 			Assert.Null(await _storage.OpenReadAsync(id));
+		}
+
+
+		[Fact]
+		public async Task Open_blob_exists_returns_stream() {
+			string existingBlobPath = $"{Guid.NewGuid()}/existing-blob.txt";
+
+			await _storage.WriteTextAsync(existingBlobPath, "Hello, Blob!");
+
+			var result = await _storage.OpenReadAsync(existingBlobPath);
+			Assert.NotNull(result);
+
+			using var reader = new StreamReader(result);
+			string content = await reader.ReadToEndAsync();
+			Assert.Equal("Hello, Blob!", content);
+		}
+
+
+		[Fact]
+		public async Task Open_empty_blob_returns_empty_stream() {
+			string emptyBlobPath = $"{Guid.NewGuid()}/empty-blob.txt";
+
+			await _storage.WriteAsync(emptyBlobPath, new MemoryStream(new byte[0]));
+			Stream result = await _storage.OpenReadAsync(emptyBlobPath);
+
+			Assert.NotNull(result);
+			Assert.Equal(0, result.Length);
 		}
 
 		[Fact]
@@ -344,7 +369,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 			string file1 = StoragePath.Combine(prefix, "1.txt");
 			string file2 = StoragePath.Combine(prefix, "sub", "2.txt");
 
-
 			try {
 				//setup
 				await _storage.WriteTextAsync(file1, "1");
@@ -354,7 +378,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				await _storage.DeleteAsync(prefix);
 			}
 			catch (NotSupportedException) {
-
 			}
 
 			//assert
@@ -376,7 +399,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				Assert.True(list.First().Name == "2");
 			}
 			catch (NotSupportedException) {
-
 			}
 		}
 
@@ -389,7 +411,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 		public async Task Rename_NewPathNull_ThowsArgumentNull() {
 			await Assert.ThrowsAsync<ArgumentNullException>(() => _storage.RenameAsync("test/1", null));
 		}
-
 
 		[Fact]
 		public async Task Rename_Folder_Renames() {
@@ -425,7 +446,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				Assert.Equal(text, text2);
 			}
 			catch (NotSupportedException) {
-
 			}
 		}
 
@@ -550,7 +570,6 @@ namespace FluentStorage.Tests.Integration.Blobs {
 				Assert.True(files.Any());  //check dummy file exists
 			}
 			catch (NotSupportedException) {
-
 			}
 		}
 

--- a/FluentStorage.Tests.Integration/Trio/MessagingFixture.cs
+++ b/FluentStorage.Tests.Integration/Trio/MessagingFixture.cs
@@ -1,6 +1,5 @@
 ﻿using FluentStorage.Messaging;
 using System;
-using Config.Net;
 using System.IO;
 using System.Reflection;
 

--- a/FluentStorage.Tests.Integration/Trio/MessagingTest.Variations.cs
+++ b/FluentStorage.Tests.Integration/Trio/MessagingTest.Variations.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using Amazon;
+﻿using Amazon;
 using FluentStorage.Azure.ServiceBus;
-using FluentStorage.Blobs;
 using FluentStorage.Messaging;
 using Xunit;
 

--- a/FluentStorage.Tests.Integration/Trio/MessagingTest.cs
+++ b/FluentStorage.Tests.Integration/Trio/MessagingTest.cs
@@ -1,11 +1,9 @@
-﻿using Xunit;
-using FluentStorage.Messaging;
+﻿using FluentStorage.Messaging;
 using System;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-using FluentStorage.Azure.ServiceBus;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
 
 namespace FluentStorage.Tests.Integration.Messaging {
 	[Trait("Category", "Messenger")]


### PR DESCRIPTION
### Fixes

Issue [97](https://github.com/robinrodricks/FluentStorage/issues/97)

### Description

I updated the OpenReadAsync method to use the Azure SDK's OpenReadAsync for streaming blob content instead of the previous implementation that used DownloadAsync. The main reasons for this change are:

### Improved Performance:

OpenReadAsync streams the blob content on demand, which is more efficient for large blobs compared to DownloadAsync, which downloads the entire blob into memory.

### Backward Compatibility:

To preserve compatibility with the old implementation, I added logic to handle empty blobs explicitly by returning a MemoryStream (as DownloadAsync previously returned for zero-sized blobs).
A comment has been added in the code to explain this backward compatibility decision for clarity.
