### PR TITLE
Enhance Azure Blob Storage SDK with OpenReadAsync for Efficient Streaming Over DownloadAsync

### DIFF
--- a/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
@@ -92,7 +92,6 @@ namespace FluentStorage.Azure.Blobs {
 			return await Task.WhenAll(fullPaths.Select(p => GetBlobAsync(p, cancellationToken))).ConfigureAwait(false);
 		}
 
-
 		public async Task<Stream> OpenReadAsync(string fullPath, CancellationToken cancellationToken = default) {
 			GenericValidation.CheckBlobFullPath(fullPath);
 
@@ -101,19 +100,21 @@ namespace FluentStorage.Azure.Blobs {
 			BlockBlobClient client = container.GetBlockBlobClient(path);
 
 			try {
-				//current SDK fails to download 0-sized files
-				Response<BlobProperties> p = await client.GetPropertiesAsync().ConfigureAwait(false);
-				if (p.Value.ContentLength == 0)
+				// Backward compatibility: Explicitly handle empty blobs to ensure they return a MemoryStream,
+				// preserving the behavior of the old implementation.
+				var properties = await client.GetPropertiesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+
+				if (properties.Value.ContentLength == 0) {
 					return new MemoryStream();
+				}
 
-				Response<BlobDownloadInfo> response = await client.DownloadAsync(cancellationToken).ConfigureAwait(false);
-
-				return response.Value.Content;
+				return await client.OpenReadAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
 			}
 			catch (RequestFailedException ex) when (ex.ErrorCode == "BlobNotFound") {
 				return null;
 			}
 		}
+
 
 		public Task<ITransaction> OpenTransactionAsync() => throw new NotImplementedException();
 

--- a/FluentStorage.Tests.Integration/Trio/BlobTest.cs
+++ b/FluentStorage.Tests.Integration/Trio/BlobTest.cs
@@ -272,6 +272,32 @@ namespace FluentStorage.Tests.Integration.Blobs {
 		}
 
 		[Fact]
+		public async Task Open_blob_exists_returns_stream() {
+			string existingBlobPath = $"{Guid.NewGuid()}/existing-blob.txt";
+
+			await _storage.WriteTextAsync(existingBlobPath, "Hello, Blob!");
+
+			var result = await _storage.OpenReadAsync(existingBlobPath);
+			Assert.NotNull(result);
+
+			using var reader = new StreamReader(result);
+			string content = await reader.ReadToEndAsync();
+			Assert.Equal("Hello, Blob!", content);
+		}
+
+
+		[Fact]
+		public async Task Open_empty_blob_returns_empty_stream() {
+			string emptyBlobPath = $"{Guid.NewGuid()}/empty-blob.txt";
+
+			await _storage.WriteAsync(emptyBlobPath, new MemoryStream(new byte[0]));
+			Stream result = await _storage.OpenReadAsync(emptyBlobPath);
+
+			Assert.NotNull(result);
+			Assert.Equal(0, result.Length);
+		}
+
+		[Fact]
 		public async Task Open_copy_to_memory_stream_succeeds() {
 			string id = await GetRandomStreamIdAsync();
 			IBlobStorage ms = StorageFactory.Blobs.InMemory();


### PR DESCRIPTION
### Fixes

Issue [97](https://github.com/robinrodricks/FluentStorage/issues/97)

### Description

I updated the OpenReadAsync method to use the Azure SDK's OpenReadAsync for streaming blob content instead of the previous implementation that used DownloadAsync. The main reasons for this change are:

### Improved Performance:

OpenReadAsync streams the blob content on demand, which is more efficient for large blobs compared to DownloadAsync, which downloads the entire blob into memory.

### Backward Compatibility:

To preserve compatibility with the old implementation, I added logic to handle empty blobs explicitly by returning a MemoryStream (as DownloadAsync previously returned for zero-sized blobs).
A comment has been added in the code to explain this backward compatibility decision for clarity.
