### PR TITLE
Added the ability to pass the Protocol property to the PresignedRequest

### DIFF
--- a/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
+++ b/FluentStorage.AWS/Blobs/AwsS3BlobStorage.cs
@@ -326,6 +326,13 @@ namespace FluentStorage.AWS.Blobs {
 		/// Get presigned url for requested operation with Blob Storage.
 		/// </summary>
 		public async Task<string> GetPresignedUrlAsync(string fullPath, string mimeType, int expiresInSeconds, HttpVerb verb) {
+			return await GetPresignedUrlAsync(fullPath, mimeType, expiresInSeconds, verb, default).ConfigureAwait(false);
+		}
+
+		/// <summary>
+		/// Get presigned url for requested operation with Blob Storage.
+		/// </summary>
+		public async Task<string> GetPresignedUrlAsync(string fullPath, string mimeType, int expiresInSeconds, HttpVerb verb, Protocol protocol) {
 			IAmazonS3 client = await GetClientAsync().ConfigureAwait(false);
 
 			return client.GetPreSignedURL(new GetPreSignedUrlRequest() {
@@ -333,6 +340,7 @@ namespace FluentStorage.AWS.Blobs {
 				ContentType = mimeType,
 				Expires = DateTime.UtcNow.AddSeconds(expiresInSeconds),
 				Key = StoragePath.Normalize(fullPath, true),
+				Protocol = protocol,
 				Verb = verb,
 			});
 		}

--- a/FluentStorage.AWS/Blobs/IAwsS3BlobStorage.cs
+++ b/FluentStorage.AWS/Blobs/IAwsS3BlobStorage.cs
@@ -33,6 +33,11 @@ namespace FluentStorage.AWS.Blobs {
 		Task<string> GetPresignedUrlAsync(string fullPath, string mimeType, int expiresInSeconds, HttpVerb verb);
 
 		/// <summary>
+		/// Get presigned url for requested operation with Blob Storage.
+		/// </summary>
+		Task<string> GetPresignedUrlAsync(string fullPath, string mimeType, int expiresInSeconds, HttpVerb verb, Protocol protocol);
+
+		/// <summary>
 		/// Set acl for object.
 		/// </summary>
 		/// <param name="fullPath"></param>


### PR DESCRIPTION
When working within an internal network, it's possible to access S3 using the HTTP protocol by setting ServiceUrl = http://s3_endpoint. However, in this case, the GetPresignedRequest method still returns a URL with HTTPS. To fix this, you need to pass the Protocol property with the value Http in the PresignedRequest.

This MR makes it possible.