### PR TITLE
Use ContentType when setting AWS Metadata

### DIFF
--- a/FluentStorage.AWS/Blobs/Converter.cs
+++ b/FluentStorage.AWS/Blobs/Converter.cs
@@ -24,6 +24,7 @@ namespace FluentStorage.AWS.Blobs {
 				DestinationBucket = bucketName,
 				SourceKey = key,
 				DestinationKey = key,
+				ContentType = (string)blob.Properties["ContentType"],
 				MetadataDirective = S3MetadataDirective.REPLACE
 			};
 


### PR DESCRIPTION
### Fixes

- Issue where content type is always set to `binary/octet-stream` on AWS

### Description

This PR sets the Content Type field correctly from the ContentType property
