### PR TITLE
Fix: Respect createIfNotExists Parameter in GetFilePath and Prevent Unintended Directory Creation

### DIFF
--- a/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
+++ b/FluentStorage/Blobs/Files/DiskDirectoryBlobStorage.cs
@@ -161,7 +161,7 @@ namespace FluentStorage.Blobs.Files {
 				fullPath = _fileSystem.Path.Combine(_directoryFullName, extraPath);
 
 				dir = fullPath;
-				if (!_fileSystem.Directory.Exists(dir))
+				if (!_fileSystem.Directory.Exists(dir) && createIfNotExists)
 					_fileSystem.Directory.CreateDirectory(dir);
 			}
 
@@ -257,7 +257,7 @@ namespace FluentStorage.Blobs.Files {
 				GenericValidation.CheckBlobFullPaths(fullPaths);
 
 				foreach (string fullPath in fullPaths) {
-					bool exists = _fileSystem.File.Exists(GetFilePath(StoragePath.Normalize(fullPath)));
+					bool exists = _fileSystem.File.Exists(GetFilePath(StoragePath.Normalize(fullPath), false));
 					result.Add(exists);
 				}
 			}


### PR DESCRIPTION
This pull request fixes unintended directory creation in DiskDirectoryBlobStorage by ensuring the GetFilePath method now properly respects the createIfNotExists parameter. As a result, directories are only created when explicitly requested.
Additionally, the call to GetFilePath within ExistsAsync now sets createIfNotExists to false, preventing side effects when checking for file existence.

Fixes
- Issue 1: GetFilePath did not respect the createIfNotExists parameter, always creating directories.
- Issue 2: ExistsAsync did not pass createIfNotExists: false to GetFilePath, causing directory creation during existence checks.

These changes ensure that file existence checks are side-effect free and that directory creation only occurs when intended.