### PR TITLE
Set Content-Type based on file extension for Azure Blob Storage

### DIFF
--- a/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
@@ -14,7 +14,7 @@ using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Blobs;
 using Microsoft.Identity.Client;
-using Microsoft.AspNetCore.StaticFiles;
+using MimeMapping;
 using FluentStorage.Blobs;
 using FluentStorage.Azure.Blobs.Gen2.Model;
 
@@ -29,8 +29,6 @@ namespace FluentStorage.Azure.Blobs {
 		private readonly string _containerName;
 		private readonly ConcurrentDictionary<string, BlobContainerClient> _containerNameToContainerClient =
 		   new ConcurrentDictionary<string, BlobContainerClient>();
-		private static readonly FileExtensionContentTypeProvider _mime =
-		   new FileExtensionContentTypeProvider();
 
 		public AzureBlobStorage(
 		   BlobServiceClient blobServiceClient,
@@ -132,10 +130,7 @@ namespace FluentStorage.Azure.Blobs {
 
 			BlockBlobClient client = container.GetBlockBlobClient(path);
 
-			string contentType;
-			if (!_mime.TryGetContentType(path, out contentType)) {
-				contentType = "application/octet-stream";
-			}
+			string contentType = MimeUtility.GetMimeMapping(path);
 			try {
 				var options = new BlobUploadOptions {
 					HttpHeaders = new BlobHttpHeaders {

--- a/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
+++ b/FluentStorage.Azure.Blobs/AzureBlobStorage.cs
@@ -14,6 +14,7 @@ using Azure.Storage.Blobs.Specialized;
 using Azure.Storage.Sas;
 using Blobs;
 using Microsoft.Identity.Client;
+using Microsoft.AspNetCore.StaticFiles;
 using FluentStorage.Blobs;
 using FluentStorage.Azure.Blobs.Gen2.Model;
 
@@ -28,6 +29,8 @@ namespace FluentStorage.Azure.Blobs {
 		private readonly string _containerName;
 		private readonly ConcurrentDictionary<string, BlobContainerClient> _containerNameToContainerClient =
 		   new ConcurrentDictionary<string, BlobContainerClient>();
+		private static readonly FileExtensionContentTypeProvider _mime =
+		   new FileExtensionContentTypeProvider();
 
 		public AzureBlobStorage(
 		   BlobServiceClient blobServiceClient,
@@ -129,9 +132,19 @@ namespace FluentStorage.Azure.Blobs {
 
 			BlockBlobClient client = container.GetBlockBlobClient(path);
 
+			string contentType;
+			if (!_mime.TryGetContentType(path, out contentType)) {
+				contentType = "application/octet-stream";
+			}
 			try {
+				var options = new BlobUploadOptions {
+					HttpHeaders = new BlobHttpHeaders {
+						ContentType = contentType
+					}
+				};
 				await client.UploadAsync(
 				   new StorageSourceStream(dataStream),
+				   options: options,
 				   cancellationToken: cancellationToken).ConfigureAwait(false);
 			}
 			catch (RequestFailedException ex) when (ex.ErrorCode == "OperationNotAllowedInCurrentState") {

--- a/FluentStorage.Azure.Blobs/FluentStorage.Azure.Blobs.csproj
+++ b/FluentStorage.Azure.Blobs/FluentStorage.Azure.Blobs.csproj
@@ -31,6 +31,7 @@
    <ItemGroup>
       <PackageReference Include="Azure.Identity" Version="1.14.2" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
+      <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
    </ItemGroup>
   
    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">

--- a/FluentStorage.Azure.Blobs/FluentStorage.Azure.Blobs.csproj
+++ b/FluentStorage.Azure.Blobs/FluentStorage.Azure.Blobs.csproj
@@ -31,7 +31,7 @@
    <ItemGroup>
       <PackageReference Include="Azure.Identity" Version="1.14.2" />
       <PackageReference Include="Azure.Storage.Blobs" Version="12.20.0" />
-      <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.3.0" />
+      <PackageReference Include="MimeMapping" Version="3.1.0" />
    </ItemGroup>
   
    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">


### PR DESCRIPTION
### Fixes

Issue #47 

### Description

Sets Content-Type header on Azure blob uploads based on file extension to ensure proper browser rendering of files (e.g., images display inline instead of downloading). 

**Implementation:**
- Detects MIME type from blob path using MimeUtility.GetMimeMapping() from the lightweight MimeMapping package
- Automatically defaults to "application/octet-stream" for unknown extensions (built into MimeMapping library)
- Sets Content-Type via BlobUploadOptions with BlobHttpHeaders during upload


