### PR TITLE
Added null check for common prefixes - it can be null in some cases

### DIFF
--- a/FluentStorage.AWS/Blobs/Converter.cs
+++ b/FluentStorage.AWS/Blobs/Converter.cs
@@ -117,10 +117,14 @@ namespace FluentStorage.AWS.Blobs {
 			//subfolders are listed in another field (what a funny name!)
 
 			//prefix is absolute too
-			result.AddRange(
-			   response.CommonPrefixes
-				  .Where(p => !StoragePath.IsRootPath(p))
-				  .Select(p => new Blob(p, BlobItemKind.Folder)));
+			// CommonPrefixes can be null https://github.com/aws/aws-sdk-net/blob/main/sdk/src/Services/S3/Generated/Model/ListObjectsV2Response.cs#L94
+			if (response.CommonPrefixes is not null)
+			{
+			    result.AddRange(
+			        response.CommonPrefixes
+			            .Where(p => !StoragePath.IsRootPath(p))
+			            .Select(p => new Blob(p, BlobItemKind.Folder)));
+			}
 
 			return result;
 		}


### PR DESCRIPTION
### Fixes Null pointer issue for some cases

Issue [# 126](https://github.com/robinrodricks/FluentStorage/issues/126)

### Description

Adds a NPE check to avoid null pointers in CommonPrefixes response
