### PR TITLE
SFTP: update OpenReadAsync() for file attributes permissions

### DIFF
--- a/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
+++ b/FluentStorage.SFTP/SshNetSftpBlobStorage.cs
@@ -361,11 +361,15 @@ namespace FluentStorage.SFTP {
 
 			SftpClient client = GetClient();
 
+			MemoryStream stream = new MemoryStream();
+
 			try {
-				byte[] fileBytes = await Task.FromResult(Policy.Handle<Exception>().Retry(MaxRetryCount).Execute(() => client.ReadAllBytes(fullPath)));
-				return new MemoryStream(fileBytes);
+				await Task.Run(() => Policy.Handle<Exception>().Retry(MaxRetryCount).Execute(() => client.DownloadFile(fullPath, stream)));
+				stream.Position = 0;
+				return stream;
 			}
 			catch (Exception /*exception*/) {
+				stream?.Dispose();
 				return null;
 			}
 		}


### PR DESCRIPTION
### Description

Related to previous Issue #133 

The earlier PR addressed upload; we've now hit a similar problem on download associated with a permissions-restrictive sftp implementation. The underlying SSHNET SftpClient ReadAllBytes method that was in use requires attribute permissions (it internally requests file size prior to downloading). The DownloadFile method also available in the client (that directly supports a stream interface as well) does not require attribute permissions and seems completely equivalent in functionality.

I'd propose this one as a direct replacement (rather than a configuration as it doesn't remove any existing behaviour). But open to your consideration on this point.
