### PR TITLE
Add AzureBlobStorage factory method accepting BlobServiceClient

### DIFF
--- a/FluentStorage.Azure.Blobs/Factory.cs
+++ b/FluentStorage.Azure.Blobs/Factory.cs
@@ -20,6 +20,18 @@ namespace FluentStorage {
 		}
 
 		/// <summary>
+		/// Creates Azure Blob Storage from an existing <see cref="BlobServiceClient"/>.
+		/// </summary>
+		public static IAzureBlobStorage AzureBlobStorage(this IBlobStorageFactory factory,
+		   BlobServiceClient blobServiceClient,
+		   string containerName = null) {
+			if (blobServiceClient is null)
+				throw new ArgumentNullException(nameof(blobServiceClient));
+
+			return new AzureBlobStorage(blobServiceClient, blobServiceClient.AccountName, containerName: containerName);
+		}
+
+		/// <summary>
 		/// Connect to local emulator
 		/// </summary>
 		public static IAzureBlobStorage AzureBlobStorageWithLocalEmulator(this IBlobStorageFactory factory) {

--- a/FluentStorage.Azure.Blobs/Factory.cs
+++ b/FluentStorage.Azure.Blobs/Factory.cs
@@ -23,10 +23,19 @@ namespace FluentStorage {
 		/// Creates Azure Blob Storage from an existing <see cref="BlobServiceClient"/>.
 		/// </summary>
 		public static IAzureBlobStorage AzureBlobStorage(this IBlobStorageFactory factory,
+		   BlobServiceClient blobServiceClient) {
+			return AzureBlobStorage(factory, blobServiceClient, null);
+		}
+
+		/// <summary>
+		/// Creates Azure Blob Storage from an existing <see cref="BlobServiceClient"/>.
+		/// </summary>
+		public static IAzureBlobStorage AzureBlobStorage(this IBlobStorageFactory factory,
 		   BlobServiceClient blobServiceClient,
-		   string containerName = null) {
-			if (blobServiceClient is null)
+		   string containerName) {
+			if (blobServiceClient is null) {
 				throw new ArgumentNullException(nameof(blobServiceClient));
+			}
 
 			return new AzureBlobStorage(blobServiceClient, blobServiceClient.AccountName, containerName: containerName);
 		}


### PR DESCRIPTION
## Summary
- Adds `StorageFactory.Blobs.AzureBlobStorage(blobServiceClient)` extension method to create `IAzureBlobStorage` directly from a `BlobServiceClient`
- Enables users to construct a `BlobServiceClient` with a native Azure connection string and pass it in, without needing reflection workarounds
- Matches the API documented in the [wiki](https://github.com/robinrodricks/FluentStorage/wiki/Azure-Blob-Storage)

## Note: Wiki is outdated
The [Azure Blob Storage wiki page](https://github.com/robinrodricks/FluentStorage/wiki/Azure-Blob-Storage) references method names from the old Storage.NET API:

| Wiki documents | Actual method |
|---|---|
| `StorageFactory.Modules.UseAzureStorage()` | `UseAzureBlobStorage()` |
| `StorageFactory.Blobs.AzureBlobStorage(accountName, accountKey)` | `AzureBlobStorageWithSharedKey(accountName, key)` |
| `StorageFactory.Blobs.AzureBlobDevelopmentStorage()` | `AzureBlobStorageWithLocalEmulator()` |
| `StorageFactory.Blobs.AzureBlobStorage(client)` | Did not exist — **added in this PR** |
| `StorageFactory.Blobs.AzureBlobStorageFromSas(sasUrl)` | `AzureBlobStorageWithSas(sas)` |
| `AccountSasPolicy(DateTime, TimeSpan)` | `AccountSasPolicy(DateTimeOffset, TimeSpan)` |

The wiki also doesn't document: `AzureBlobStorageWithAzureAd`, `AzureBlobStorageWithTokenCredential`, `AzureBlobStorageWithMsi`, or the `AzureCloudEnvironment` overloads.
