### PR TITLE
Make hash helpers thread-safe (fixes #72)

### DIFF
--- a/FluentStorage.Tests/Utils/ByteArrayExtensionsTest.cs
+++ b/FluentStorage.Tests/Utils/ByteArrayExtensionsTest.cs
@@ -34,13 +34,13 @@
 
 		[Fact]
 		public void Hash_helpers_can_be_called_concurrently() {
-			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72: the MD5 and
+			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72. The MD5 and
 			// SHA256 helpers used to share a single static HashAlgorithm instance, which is not
 			// thread-safe and throws "Concurrent operations from multiple threads on this type are not
-			// supported" when used concurrently (e.g. concurrent InMemoryBlobStorage writes). Two threads
-			// hash the same data at once; each loops enough times that the two reliably overlap inside
-			// the hash (the race only trips while both are inside ComputeHash at the same moment, so a
-			// short loop can miss).
+			// supported" when called concurrently, for example during concurrent InMemoryBlobStorage
+			// writes. Two threads hash the same data at the same time, each looping enough that they
+			// reliably overlap inside the hash. The race only trips while both threads are hashing at the
+			// same moment, so a short loop can miss.
 			byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
 			byte[] expectedMd5 = data.MD5()!;
 			byte[] expectedSha256 = data.SHA256()!;

--- a/FluentStorage.Tests/Utils/ByteArrayExtensionsTest.cs
+++ b/FluentStorage.Tests/Utils/ByteArrayExtensionsTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace FluentStorage.Tests.Utils {
 	using FluentStorage.Utils.Extensions;
-	using global::System;
+	using global::System.Text;
+	using global::System.Threading.Tasks;
 	using Xunit;
 
 	public class ByteArrayExtensionsTest {
@@ -12,6 +13,46 @@
 			string? actual = input.ToHexString();
 
 			Assert.Equal(expected, actual);
+		}
+
+		[Fact]
+		public void MD5_hashes_to_the_expected_value() {
+			byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
+
+			Assert.Equal("9e107d9d372bb6826bd81d3542a419d6", data.MD5().ToHexString());
+		}
+
+		[Fact]
+		public void SHA256_hashes_to_the_expected_value() {
+			byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
+
+			Assert.Equal(
+				"d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592",
+				data.SHA256().ToHexString()
+			);
+		}
+
+		[Fact]
+		public void Hash_helpers_can_be_called_concurrently() {
+			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72: the MD5 and
+			// SHA256 helpers used to share a single static HashAlgorithm instance, which is not
+			// thread-safe and throws "Concurrent operations from multiple threads on this type are not
+			// supported" when used concurrently (e.g. concurrent InMemoryBlobStorage writes). Two threads
+			// hash the same data at once; each loops enough times that the two reliably overlap inside
+			// the hash (the race only trips while both are inside ComputeHash at the same moment, so a
+			// short loop can miss).
+			byte[] data = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
+			byte[] expectedMd5 = data.MD5()!;
+			byte[] expectedSha256 = data.SHA256()!;
+
+			void Hash() {
+				for (var j = 0; j < 2000; j++) {
+					Assert.Equal(expectedMd5, data.MD5());
+					Assert.Equal(expectedSha256, data.SHA256());
+				}
+			}
+
+			Task.WaitAll(Task.Run(Hash), Task.Run(Hash));
 		}
 	}
 }

--- a/FluentStorage.Tests/Utils/StreamExtensionsTest.cs
+++ b/FluentStorage.Tests/Utils/StreamExtensionsTest.cs
@@ -1,0 +1,42 @@
+﻿namespace FluentStorage.Tests.Utils {
+	using FluentStorage.Utils.Extensions;
+	using global::System.IO;
+	using global::System.Text;
+	using global::System.Threading.Tasks;
+	using Xunit;
+
+	public class StreamExtensionsTest {
+		[Fact]
+		public void MD5_hashes_a_stream_to_the_expected_value() {
+			using var stream = new MemoryStream(
+				Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog")
+			);
+
+			byte[] hash = stream.MD5();
+
+			Assert.Equal("9e107d9d372bb6826bd81d3542a419d6", hash.ToHexString());
+		}
+
+		[Fact]
+		public void MD5_can_be_called_concurrently() {
+			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72: Stream.MD5()
+			// used a shared static HashAlgorithm instance, which is not thread-safe. Each call gets its
+			// own stream (a Stream is stateful); the shared hash was the bug. Two threads hash at once;
+			// each loops enough times that the two reliably overlap inside the hash.
+			byte[] content = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
+			byte[] expected;
+			using (var seed = new MemoryStream(content)) {
+				expected = seed.MD5();
+			}
+
+			void Hash() {
+				for (var j = 0; j < 2000; j++) {
+					using var stream = new MemoryStream(content);
+					Assert.Equal(expected, stream.MD5());
+				}
+			}
+
+			Task.WaitAll(Task.Run(Hash), Task.Run(Hash));
+		}
+	}
+}

--- a/FluentStorage.Tests/Utils/StreamExtensionsTest.cs
+++ b/FluentStorage.Tests/Utils/StreamExtensionsTest.cs
@@ -19,10 +19,11 @@
 
 		[Fact]
 		public void MD5_can_be_called_concurrently() {
-			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72: Stream.MD5()
-			// used a shared static HashAlgorithm instance, which is not thread-safe. Each call gets its
-			// own stream (a Stream is stateful); the shared hash was the bug. Two threads hash at once;
-			// each loops enough times that the two reliably overlap inside the hash.
+			// Regression test for https://github.com/robinrodricks/FluentStorage/issues/72. The Stream
+			// MD5 helper used a shared static HashAlgorithm instance, which is not thread-safe. Each call
+			// already gets a fresh stream, so the shared hash instance was the only state being raced.
+			// Two threads hash at the same time, each looping enough that they reliably overlap inside
+			// the hash.
 			byte[] content = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog");
 			byte[] expected;
 			using (var seed = new MemoryStream(content)) {

--- a/FluentStorage/Utils/Extensions/ByteArrayExtensions.cs
+++ b/FluentStorage/Utils/Extensions/ByteArrayExtensions.cs
@@ -8,8 +8,6 @@
 	public static class ByteArrayExtensions {
 		private static readonly char[] LowerCaseHexAlphabet = "0123456789abcdef".ToCharArray();
 		private static readonly char[] UpperCaseHexAlphabet = "0123456789ABCDEF".ToCharArray();
-		private static readonly Crypto.MD5 _md5 = Crypto.MD5.Create();
-		private static readonly Crypto.SHA256 _sha256 = Crypto.SHA256.Create();
 
 
 		/// <summary>
@@ -44,14 +42,27 @@
 			if (bytes == null)
 				return null;
 
-			return _md5.ComputeHash(bytes);
+			// A HashAlgorithm instance is not thread-safe, so it must never be shared across threads
+			// (https://github.com/robinrodricks/FluentStorage/issues/72). Use the allocation-free,
+			// thread-safe one-shot API where available, and a per-call instance on older targets.
+#if NET5_0_OR_GREATER
+			return Crypto.MD5.HashData(bytes);
+#else
+			using var md5 = Crypto.MD5.Create();
+			return md5.ComputeHash(bytes);
+#endif
 		}
 
 		public static byte[]? SHA256(this byte[]? bytes) {
 			if (bytes == null)
 				return null;
 
-			return _sha256.ComputeHash(bytes);
+#if NET5_0_OR_GREATER
+			return Crypto.SHA256.HashData(bytes);
+#else
+			using var sha256 = Crypto.SHA256.Create();
+			return sha256.ComputeHash(bytes);
+#endif
 		}
 
 		public static byte[]? HMACSHA256(this byte[]? data, byte[] key) {

--- a/FluentStorage/Utils/Extensions/StreamExtensions.cs
+++ b/FluentStorage/Utils/Extensions/StreamExtensions.cs
@@ -105,13 +105,19 @@
 
 		#endregion
 
-		private static readonly Crypto.MD5 _md5 = Crypto.MD5.Create();
-
 		public static byte[] MD5(this Stream? bytes) {
 			if (bytes == null)
 				return null;
 
-			return _md5.ComputeHash(bytes);
+			// A HashAlgorithm instance is not thread-safe, so it must never be shared across threads
+			// (https://github.com/robinrodricks/FluentStorage/issues/72). Use the allocation-free,
+			// thread-safe one-shot API where available, and a per-call instance on older targets.
+#if NET5_0_OR_GREATER
+			return Crypto.MD5.HashData(bytes);
+#else
+			using var md5 = Crypto.MD5.Create();
+			return md5.ComputeHash(bytes);
+#endif
 		}
 
 	}


### PR DESCRIPTION
## Problem

`ByteArrayExtensions` and `StreamExtensions` compute hashes through **single, process-wide static `HashAlgorithm` instances**:

```csharp
private static readonly Crypto.MD5 _md5 = Crypto.MD5.Create();
private static readonly Crypto.SHA256 _sha256 = Crypto.SHA256.Create();
```

A `HashAlgorithm` is **not thread-safe**, so calling these helpers from multiple threads throws:

```
System.Security.Cryptography.CryptographicException:
Concurrent operations from multiple threads on this type are not supported.
```

This is easy to hit in practice because `InMemoryBlobStorage.Write` hashes **every** write via `data.MD5()`, so writing blobs from multiple threads (parallel tests, concurrent request handling, etc.) fails intermittently. Reported in #72.

## Fix

Hash with a **per-call instance** instead of a shared static:

- On **.NET 5+**, use the allocation-free, thread-safe one-shot `MD5.HashData` / `SHA256.HashData`.
- On **netstandard2.0 / 2.1**, create and dispose a per-call instance with `using` (consistent with the existing `HMACSHA256` helper in the same file).

Only the instance lifecycle changes; the hash output is identical. The change covers all three affected helpers: `ByteArrayExtensions.MD5`, `ByteArrayExtensions.SHA256`, and `StreamExtensions.MD5`.

## Tests

Adds:
- **Known-value tests** for `ByteArrayExtensions.MD5`/`SHA256` and `StreamExtensions.MD5`, asserting the canonical vectors for `"The quick brown fox jumps over the lazy dog"`.
- **Concurrency regression tests** for the `byte[]` helpers (`Hash_helpers_can_be_called_concurrently`, covering `MD5` and `SHA256`) and the `Stream` helper (`MD5_can_be_called_concurrently`). Two threads hash concurrently, each looping enough that they reliably overlap inside `ComputeHash` (the race only trips while both threads are inside it at the same moment). These **fail on the unfixed code** (reproduced the `CryptographicException` in 30/30 runs) and **pass with this fix**, in a few tens of ms.

Verified the library compiles across every target framework (`netstandard2.0;netstandard2.1;net7.0;net8.0;net9.0`), so both branches of the `#if` build.

Fixes #72.
