### PR TITLE
Fix: Azure Blob paths lose their first character

### DIFF
--- a/FluentStorage.Azure.Blobs/Storage/AzureBlobStore.cs
+++ b/FluentStorage.Azure.Blobs/Storage/AzureBlobStore.cs
@@ -606,7 +606,7 @@ namespace FluentStorage.Azure.Blobs.Storage {
 				}
 				else {
 					containerName = parts[0];
-					relativePath = StoragePath.Combine(parts.Skip(1)).Substring(1);
+					relativePath = StoragePath.Combine(parts.Skip(1));
 				}
 			}
 			else {


### PR DESCRIPTION
This fixes a serious bug with Azure Blobs: All filenames where stored with the first letter removed.

### Fixes

Could not find issue number

### Description

Splitting the full path into container + relative path did this:

```csharp
containerName = parts[0];
relativePath = StoragePath.Combine(parts.Skip(1)).Substring(1);
```

StoragePath.Combine already returns the combined path without a leading separator, so Substring(1) removed the first character of the name itself rather than a delimiter. Writing to `mycontainer/test.txt` produced a blob actually named `est.txt` in the container.

The existing tests didn't catch this: every operation — read, write, exists, delete — resolves its path through GetPartsAsync, so all of them were truncated identically. Round-trips succeeded because the same mangled name was used on both sides; nothing asserted against the name as it exists in the container, so the tests were passing on the wrong filename.