### PR TITLE
Fix MaxResults loop guard in S3DirectoryBrowser.ListFolderAsync

### DIFF
--- a/FluentStorage.AWS/Storage/S3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Storage/S3DirectoryBrowser.cs
@@ -54,7 +54,7 @@ class S3DirectoryBrowser : IDisposable {
 
 		var folderContainer = new List<StoreObject>();
 
-		while (options.MaxResults == null || (container.Count < options.MaxResults)) {
+		while (options.MaxResults == null || (container.Count + folderContainer.Count < options.MaxResults)) {
 			ListObjectsV2Response response;
 
 			using (await _limiter.AcquireOneAsync().ConfigureAwait(false)) {


### PR DESCRIPTION
### Fixes

No related issue filed - root cause and fix are both described below.

### Description

`S3DirectoryBrowser.ListFolderAsync`'s pagination loop is guarded by `container.Count < options.MaxResults`, but `container` is only populated via `container.AddRange(folderContainer)` **after** the loop exits:

```csharp
var folderContainer = new List<StoreObject>();

while (options.MaxResults == null || (container.Count < options.MaxResults)) {
    ...
    folderContainer.AddRange(response.ToBlobs(options));
    ...
}

container.AddRange(folderContainer); // only filled here
```

So `container.Count` stays at whatever it was when the call started - `0` for a plain (non-recursive-local) listing - for the entire duration of the loop, and `MaxResults` never actually stops the pagination. The loop keeps calling `ListObjectsV2Async` via `NextContinuationToken` until the whole prefix has been enumerated; only the `Take(MaxResults)` in `ListAsync` trims the result afterwards, once everything has already been fetched.

Against a small bucket this is invisible (everything fits in one page), which is why it's easy to miss in local/emulated testing. Against a bucket with a large number of objects under the listed prefix, a caller asking for e.g. `MaxResults = 10` still pays for a full, sequential scan of the entire prefix (1000 keys per round trip) before anything is returned - which can easily time out the caller.

We hit this in production: a `MaxResults`-capped listing against a real S3 bucket with a large number of keys under the prefix was timing out, while the same code against a small local S3-compatible emulator was fine. Decompiling the referenced package version and then reading this loop in source is what turned up the root cause above.

### Fix

Include `folderContainer.Count` (the objects already fetched by this call) in the guard, so the loop stops as soon as the requested number of results has actually been collected:

```csharp
while (options.MaxResults == null || (container.Count + folderContainer.Count < options.MaxResults)) {
```

This only changes the termination condition of the pagination loop - result shape, ordering, and the existing final `Take(MaxResults)` trim are untouched.

### Test plan

- `dotnet build FluentStorage.AWS` succeeds with no new warnings/errors.
- No automated regression test added: reproducing the loop actually paging past what's needed requires a prefix with more than one page (1000+ objects) worth of keys, which isn't practical to set up in this repo's existing unit/integration test harness.
- Not yet re-verified against the original production bucket that surfaced this (that bucket is behind an internal deployment) - this PR is the root-cause fix derived from tracing the code, not a bucket-verified repro in this repo. Happy to add a targeted test if there's a preferred way to simulate a multi-page listing here.
