### PR TITLE
Fix listing returning no results: drop stale Substring(1) on normalized paths

### DIFF
--- a/FluentStorage.AWS/Storage/S3DirectoryBrowser.cs
+++ b/FluentStorage.AWS/Storage/S3DirectoryBrowser.cs
@@ -83,7 +83,7 @@ class S3DirectoryBrowser : IDisposable {
 
 
 	private static string FormatFolderPrefix(string folderPath) {
-		folderPath = StoragePath.Normalize(folderPath).Substring(1);
+		folderPath = StoragePath.Normalize(folderPath);
 
 		if (StoragePath.IsRootPath(folderPath))
 			return null;

--- a/FluentStorage.AWS/Utils/AwsConverter.cs
+++ b/FluentStorage.AWS/Utils/AwsConverter.cs
@@ -41,7 +41,7 @@ static class AwsConverter {
 		if (blob == null)
 			return;
 
-		GetObjectMetadataResponse obj = await client.GetObjectMetadataAsync(bucketName, blob.FullPath.Substring(1), cancellationToken).ConfigureAwait(false);
+		GetObjectMetadataResponse obj = await client.GetObjectMetadataAsync(bucketName, blob.FullPath, cancellationToken).ConfigureAwait(false);
 
 		AddMetadata(blob, obj);
 	}

--- a/FluentStorage.Azure.Blobs/Storage/AzureContainerBrowser.cs
+++ b/FluentStorage.Azure.Blobs/Storage/AzureContainerBrowser.cs
@@ -67,7 +67,7 @@ class AzureContainerBrowser : IDisposable {
 	}
 
 	private static string FormatFolderPrefix(string folderPath) {
-		folderPath = StoragePath.Normalize(folderPath).Substring(1);
+		folderPath = StoragePath.Normalize(folderPath);
 
 		if (StoragePath.IsRootPath(folderPath))
 			return null;

--- a/FluentStorage.Azure.KeyVault/Storage/AzureKeyVaultStore.cs
+++ b/FluentStorage.Azure.KeyVault/Storage/AzureKeyVaultStore.cs
@@ -201,7 +201,7 @@ public class AzureKeyVaultStore : StoreBase {
 
 
 	private static string NormaliseSecretName(string fullPath) {
-		fullPath = StoragePath.Normalize(fullPath).Substring(1);
+		fullPath = StoragePath.Normalize(fullPath);
 
 		if (!secretNameRegex.IsMatch(fullPath)) {
 			throw new NotSupportedException($"secret '{fullPath}' does not match expected pattern '^[0-9a-zA-Z-]+$'");

--- a/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.FileList.cs
+++ b/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.FileList.cs
@@ -41,6 +41,20 @@ public partial class IStoreTest {
 	}
 
 	[Fact]
+	public async Task ListObjects_FolderPath_ReturnsObjectsInThatFolder() {
+		string folder = RandomFolder();
+
+		await CreateText($"{folder}/b.txt");
+
+		var list = (await _storage.ListObjects(new StorageListOptions { FolderPath = folder, Recurse = true }))
+			.Where(f => f.Type == StorageObjectType.File).ToList();
+
+		Assert.Single(list);
+
+		Assert.Equal($"{folder}/b.txt", list[0].FullPath);
+	}
+
+	[Fact]
 	public async Task ListObjects_AfterDelete_DoesNotContainDeletedObject() {
 		string file = RandomFile();
 


### PR DESCRIPTION
### Summary

Four call sites still carry a `Substring(1)` that compensated for a leading slash
`StoragePath.Normalize` stopped emitting in 8.x. They now strip the first character of a
real path segment and throw on the empty (root) path. The most visible consequence is that
**every** `ListObjects` / `ListDirectory` against S3 and S3-compatible storage returns zero
entries, and listing the bucket root throws — S3 support is effectively unusable.

This PR removes the four stale `Substring(1)` calls and adds a regression test to the
shared provider test suite.

### Cause

`StoragePath.Normalize` used to return paths with a leading slash. Since 8.x it does not.
Its own doc comment documents the current contract:

```
Normalize(null)                  == ""
Normalize("")                    == ""
Normalize("/")                   == ""
Normalize("app1")                == "app1"
Normalize("/app1")               == "app1"
Normalize("app1/Assets")         == "app1/Assets"
Normalize("\\folder\\file.txt")  == "folder/file.txt"
```

Four sites were never updated to match. The rest of the codebase already assumes the
current semantics, which is what makes these four inconsistent leftovers rather than a
deliberate convention:

- `S3Store` passes `StoragePath.Normalize(fullPath)` straight through as the S3 `Key` at
  every other key-building site (lines 313, 327, 376, 398, 595, 639, 668, …).
- `AzureBlobStore` uses it directly as the blob name (`AzureBlobStore.cs:554`, `:594`).

So the normalized path *is* the storage key everywhere else. Only these four sites still
shave a character off it.

### Effect

**S3 and S3-compatible storage** (MinIO, RustFS, Wasabi, Cloudflare R2, DigitalOcean,
Vultr, Hetzner, B2)

`S3DirectoryBrowser.FormatFolderPrefix` builds the `ListObjectsV2Request.Prefix`. With the
first character removed, S3 is asked for a prefix that matches nothing, so every listing
comes back empty. For the bucket root, `Normalize("")` yields `""` and `Substring(1)`
throws `ArgumentOutOfRangeException`.

`AwsConverter.AppendMetadataAsync` truncates the object key the same way, so
`ListObjects(IncludeAttributes: true)` cannot resolve metadata for any object.

**Azure Blobs**

`AzureContainerBrowser.FormatFolderPrefix` is byte-identical to the S3 method and feeds
`GetBlobsByHierarchyAsync(prefix:)`. Same failure.

**Azure Key Vault**

`NormaliseSecretName` drops the first character of every secret name, so all secret
operations address the wrong secret (`"mysecret"` -> `"ysecret"`). The existing
`^[0-9a-zA-Z-]+$` guard still passes on the truncated name, so this fails silently rather
than loudly.

### Reproduction

Measured against MinIO and RustFS, identical behaviour in 8.0.10 and 8.0.20:

| `FolderPath` | Result |
|---|---|
| `"app1"`  | 0 entries |
| `"Xapp1"` | exactly the contents of `app1` — the leading character is eaten |
| `"X"`     | the entire bucket |
| `"/"`     | `ArgumentOutOfRangeException` |

The root-path crash is already reachable from the existing test suite without any new
test: `StorageListOptions.FolderPath` defaults to `""`, so a bare `ListObjects()` hits
`Normalize("").Substring(1)`.

### Fix

Remove the `Substring(1)` at all four sites:

| File | Change |
|---|---|
| `FluentStorage.AWS/Storage/S3DirectoryBrowser.cs:86` | `Normalize(folderPath).Substring(1)` -> `Normalize(folderPath)` |
| `FluentStorage.AWS/Utils/AwsConverter.cs:44` | `blob.FullPath.Substring(1)` -> `blob.FullPath` |
| `FluentStorage.Azure.Blobs/Storage/AzureContainerBrowser.cs:70` | `Normalize(folderPath).Substring(1)` -> `Normalize(folderPath)` |
| `FluentStorage.Azure.KeyVault/Storage/AzureKeyVaultStore.cs:204` | `Normalize(fullPath).Substring(1)` -> `Normalize(fullPath)` |

The root case stays correct without any extra branch: `Normalize("/") == ""` and
`StoragePath.IsRootPath("") == true`, so `FormatFolderPrefix` still returns `null` to mean
"the whole bucket/container".

For `AwsConverter`, `StoreObject.FullPath` is assigned `StoragePath.Normalize(...)` in
`StoreObject.SetFullPath` (and via `StoragePath.Combine` in the two-arg constructor), so it
is already a valid S3 key and needs no further transformation.

### Deliberately not changed

`SftpStore.cs:267` and `:305` use `FullPath.Substring(RootDirectory.Length + 1)`, which
looks like the same pattern. It was reviewed and left alone: `RootDirectory` is itself
`StoragePath.Normalize`d (`SftpStore.cs:95`), and `FullPath` is normalized too, so the
`+ 1` correctly accounts for the separator between them. That code is already correct
under the current semantics.

### Test

Adds `ListObjects_FolderPath_ReturnsObjectsInThatFolder` to the shared `IStoreTest` suite,
so it runs against every provider fixture:

```csharp
[Fact]
public async Task ListObjects_FolderPath_ReturnsObjectsInThatFolder() {
	string folder = RandomFolder();

	await CreateText($"{folder}/b.txt");

	var list = (await _storage.ListObjects(new StorageListOptions { FolderPath = folder, Recurse = true }))
		.Where(f => f.Type == StorageObjectType.File).ToList();

	Assert.Single(list);

	Assert.Equal($"{folder}/b.txt", list[0].FullPath);
}
```

It follows the conventions of the surrounding file: `RandomFolder()` for isolation against
a shared test bucket, and the same `.Where(f => f.Type == StorageObjectType.File)` filter
that `ListDirectory_Recursive_ReturnsNestedFiles` uses, so providers that emit folder
marker entries are not penalised. Against the unfixed code this assertion returns 0 entries
on S3 and Azure Blobs.

### Verification

- Solution builds with **0 errors** (2389 warnings, all pre-existing).
- The new test **passes** on the Memory and LocalDisk providers.
- Unit suite: **607/609**. The 2 failures (`LocalDiskMessagingTest`) are pre-existing and
  flaky — verified against a stashed baseline over three runs each, where they fluctuate
  between 1 and 2 failures independently of this change.
- Memory + LocalDisk suites: **430/434**. The same 4 failures occur on the stashed baseline
  (428/432) and are unrelated to this change.

**Not verified locally:** the S3, MinIO and Azure code paths themselves. The integration
suite requires a `fluentstorage.yaml` with live credentials, so the cloud providers could
not be exercised here. The S3 fix rests on the MinIO/RustFS measurements in the
Reproduction table plus the source analysis above, not on a test run in this environment.

### Reviewer notes

Two things worth a second opinion:

1. **Scope.** Only the S3 path was measured against a live server. The Azure Blobs, Azure
   Key Vault and `AwsConverter` fixes are the same root cause and are provable from the
   source, but they are not backed by a live measurement. Each is a separate one-line
   change and can be dropped if you would rather keep this PR strictly to S3.
2. **Shared test suite.** The new test lives in `IStoreTest`, so it runs against *all*
   provider fixtures. That is what gives it S3 coverage in CI, but it also holds every
   provider to this assertion — including any with genuinely different folder semantics.

### Changed files

```
FluentStorage.AWS/Storage/S3DirectoryBrowser.cs                            (1 line)
FluentStorage.AWS/Utils/AwsConverter.cs                                    (1 line)
FluentStorage.Azure.Blobs/Storage/AzureContainerBrowser.cs                 (1 line)
FluentStorage.Azure.KeyVault/Storage/AzureKeyVaultStore.cs                 (1 line)
FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.FileList.cs   (+14 lines)

5 files changed, 18 insertions(+), 4 deletions(-)
```
