### PR TITLE
Fix NullReferenceException from AWS SDK v4 returning null response collections

### DIFF
--- a/FluentStorage.AWS/Messaging/Converter.cs
+++ b/FluentStorage.AWS/Messaging/Converter.cs
@@ -30,8 +30,10 @@ static class Converter {
 		var r = new QueueMessage(sqsMessage.Body);
 		r.Id = sqsMessage.MessageId;
 
-		foreach (KeyValuePair<string, MessageAttributeValue> attr in sqsMessage.MessageAttributes) {
-			r.Properties[attr.Key] = attr.Value.StringValue;
+		if (sqsMessage.MessageAttributes != null) {
+			foreach (KeyValuePair<string, MessageAttributeValue> attr in sqsMessage.MessageAttributes) {
+				r.Properties[attr.Key] = attr.Value.StringValue;
+			}
 		}
 		r.Properties[ReceiptHandlePropertyName] = sqsMessage.ReceiptHandle;
 

--- a/FluentStorage.AWS/Messaging/SqsMessageReceiver.cs
+++ b/FluentStorage.AWS/Messaging/SqsMessageReceiver.cs
@@ -46,7 +46,7 @@ class SQSMessageReceiver : PollingMessageReceiver {
 
 		ReceiveMessageResponse messages = await _client.ReceiveMessageAsync(request, cancellationToken).ConfigureAwait(false);
 
-		return messages.Messages.Select(Converter.ToQueueMessage).ToList();
+		return messages.Messages?.Select(Converter.ToQueueMessage).ToList() ?? new List<QueueMessage>();
 	}
 
 	public override async Task<List<QueueMessage>> PeekMessages(int maxMessages, CancellationToken cancellationToken = default) {
@@ -59,7 +59,7 @@ class SQSMessageReceiver : PollingMessageReceiver {
 		};
 
 		ReceiveMessageResponse messages = await _client.ReceiveMessageAsync(request, cancellationToken).ConfigureAwait(false);
-		return messages.Messages.Select(Converter.ToQueueMessage).ToList();
+		return messages.Messages?.Select(Converter.ToQueueMessage).ToList() ?? new List<QueueMessage>();
 	}
 
 	public override Task DeadLetterMessage(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default) {

--- a/FluentStorage.AWS/Messaging/SqsMessenger.cs
+++ b/FluentStorage.AWS/Messaging/SqsMessenger.cs
@@ -52,7 +52,7 @@ class SQSMessenger : IQueue {
 	public async Task<List<string>> ListChannels(CancellationToken cancellationToken = default) {
 		ListQueuesResponse queues = await _client.ListQueuesAsync(new ListQueuesRequest { }).ConfigureAwait(false);
 
-		return queues.QueueUrls.Select(u => u.Substring(u.LastIndexOf("/") + 1)).ToList();
+		return queues.QueueUrls?.Select(u => u.Substring(u.LastIndexOf("/") + 1)).ToList() ?? new List<string>();
 	}
 
 	public async Task DeleteChannels(IEnumerable<string> channelNames, CancellationToken cancellationToken = default) {
@@ -124,7 +124,7 @@ class SQSMessenger : IQueue {
 
 		ReceiveMessageResponse messages = await _client.ReceiveMessageAsync(request, cancellationToken).ConfigureAwait(false);
 
-		return messages.Messages.Select(Converter.ToQueueMessage).ToList();
+		return messages.Messages?.Select(Converter.ToQueueMessage).ToList() ?? new List<QueueMessage>();
 	}
 
 	public void Dispose() {

--- a/FluentStorage.AWS/Storage/S3Store.cs
+++ b/FluentStorage.AWS/Storage/S3Store.cs
@@ -702,7 +702,7 @@ public class S3Store : StoreBase, IS3Storage {
 					VersionIdMarker = versionMarker
 				}, cancellationToken).ConfigureAwait(false);
 
-				foreach (S3ObjectVersion version in response.Versions) {
+				foreach (S3ObjectVersion version in response.Versions ?? Enumerable.Empty<S3ObjectVersion>()) {
 
 					if (!string.Equals(version.Key, objectPath, StringComparison.Ordinal))
 						continue;
@@ -765,7 +765,7 @@ public class S3Store : StoreBase, IS3Storage {
 					VersionIdMarker = versionMarker
 				}, cancellationToken).ConfigureAwait(false);
 
-				foreach (S3ObjectVersion version in response.Versions) {
+				foreach (S3ObjectVersion version in response.Versions ?? Enumerable.Empty<S3ObjectVersion>()) {
 
 					if (!string.Equals(version.Key, objectPath, StringComparison.Ordinal))
 						continue;
@@ -1062,7 +1062,7 @@ public class S3Store : StoreBase, IS3Storage {
 			MaxKeys = 1
 		}, cancellationToken).ConfigureAwait(false);
 
-		return response.S3Objects.Count > 0;
+		return (response.S3Objects?.Count ?? 0) > 0;
 	}
 
 }

--- a/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.FileMetadata.cs
+++ b/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.FileMetadata.cs
@@ -24,6 +24,11 @@ public partial class IStoreTest {
 	}
 
 	[Fact]
+	public async Task DirectoryExists_MissingDirectory_ReturnsFalse() {
+		Assert.False(await _storage.DirectoryExists(RandomFolder()));
+	}
+
+	[Fact]
 	public async Task ObjectsExists_ReturnsStatusForEveryObject() {
 		string f1 = RandomFile();
 		string f2 = RandomFile();


### PR DESCRIPTION
## Cause

AWS SDK for .NET v4 changed the behaviour of response collections: where v3 returned an
empty list, v4 returns `null`. `FluentStorage.AWS` 8.x requires `AWSSDK.S3 >= 4.0.100.2`
(and pins `AWSSDK.Core`, `AWSSDK.SecurityToken` and `AWSSDK.SQS` to the same version), so
every unconditional access to a response collection can now dereference null.

## Effect

The reported symptom is in `S3Store.DirectoryExists`:

    return response.S3Objects.Count > 0;

For a prefix with nothing under it, `S3Objects` is null, so `DirectoryExists("does/not/exist/")`
throws `NullReferenceException` instead of returning `false`. Measured against MinIO and RustFS.

The same pattern occurs at seven further sites, listed below. The SQS ones are on hot paths:
`ReceiveMessageResponse.Messages` is null whenever a poll returns no messages, so receiving
from an idle queue throws.

## Fix

Treat a null collection as empty at each site.

### Fixed

| Site | Collection | Symptom |
|---|---|---|
| `S3Store.DirectoryExists` (`S3Store.cs:1065`) | `S3Objects` | throws for a prefix with no objects |
| `S3Store.ListObjectVersions` (`S3Store.cs:705`) | `Versions` | throws on an unversioned bucket or a prefix with no versions |
| `S3Store.GetObjectVersion` (`S3Store.cs:768`) | `Versions` | same |
| `SQSMessageReceiver.ReceiveMessagesAsync` (`SqsMessageReceiver.cs:49`) | `Messages` | throws when a poll returns nothing |
| `SQSMessageReceiver.PeekMessages` (`SqsMessageReceiver.cs:62`) | `Messages` | same |
| `SQSMessenger.ReceiveInternalAsync` (`SqsMessenger.cs:127`) | `Messages` | same |
| `SQSMessenger.ListChannels` (`SqsMessenger.cs:55`) | `QueueUrls` | throws when the account has no queues |
| `Converter.ToQueueMessage` (`Converter.cs:33`) | `MessageAttributes` | throws for a message without attributes |

Both `Versions` loops terminate on `IsTruncated`, not on the collection, so a null page
means "no versions on this page" and not "stop" — treating it as empty is safe.

The style follows each file: `?.` with `??` for the LINQ chains, matching the existing
`response.Tagging?.ToDictionary(…) ?? new Dictionary<string, string>()` in `S3Store`; and
an `if (… != null)` wrapper in `Converter.cs`, matching the guard already applied to
`message.Properties` in the method directly above.

### Already null-safe, left unchanged

- `AwsConverter.ToBlobs` — `S3Objects` and `CommonPrefixes` are guarded with `is not null`.
- `S3Store.GetObjectTags` — `Tagging` is guarded with `?.`.

`DeleteMarkers`, `Buckets` and `Contents` do not appear in this project.

### Not changed — null carries a different meaning

`S3DirectoryBrowser.DeleteRecursiveAsync` (`S3DirectoryBrowser.cs:107`) uses
`if (response?.S3Objects == null) break;`, where null is a loop *termination criterion*
rather than "empty". It cannot throw, so it is out of scope for this fix. It may still
deserve a look: under v4 semantics a null page means "empty page" rather than "no more
data", so it could in principle stop early on an empty page that still carries a
`NextContinuationToken`. Deliberately left for a separate change.

## Test

Adds `DirectoryExists_MissingDirectory_ReturnsFalse` to the shared `IStoreTest` suite,
alongside the existing `ObjectExists_MissingObject_ReturnsFalse`:

```csharp
[Fact]
public async Task DirectoryExists_MissingDirectory_ReturnsFalse() {
	Assert.False(await _storage.DirectoryExists(RandomFolder()));
}
