### PR TITLE
Fix MoveDirectory on the disk provider always throwing ArgumentNullException

### DIFF
--- a/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.DirMove.cs
+++ b/FluentStorage.Tests/Integration/Storage/TestSuite/IStoreTest.DirMove.cs
@@ -1,0 +1,68 @@
+﻿namespace FluentStorage.Tests.Integration.Storage.TestSuite;
+
+public partial class IStoreTest {
+
+
+	// ---------------------------------------------------------------------
+	// MoveDirectory
+	// ---------------------------------------------------------------------
+
+	[Fact]
+	public async Task MoveDirectory_WithContent_MovesFilesToDestination() {
+		string source = RandomFolder();
+		string destination = RandomFolder();
+
+		await CreateText($"{source}/a.txt", "one");
+		await CreateText($"{source}/child/b.txt", "two");
+
+		try {
+			await _storage.MoveDirectory(source, destination);
+		}
+		catch (NotImplementedException) {
+			return;
+		}
+
+		Assert.Equal("one", await _storage.GetText($"{destination}/a.txt"));
+		Assert.Equal("two", await _storage.GetText($"{destination}/child/b.txt"));
+
+		Assert.False(await _storage.ObjectExists($"{source}/a.txt"));
+	}
+
+	[Fact]
+	public async Task MoveDirectory_EmptyFolder_DestinationExists() {
+		string source = RandomFolder();
+		string destination = RandomFolder();
+
+		try {
+			await _storage.CreateDirectory(source, false);
+
+			await _storage.MoveDirectory(source, destination);
+		}
+		catch (NotImplementedException) {
+			return;
+		}
+		catch (NotSupportedException) {
+			return;
+		}
+
+		Assert.True(await _storage.DirectoryExists(destination));
+	}
+
+	[Fact]
+	public async Task MoveDirectory_DestinationParentDoesNotExist_IsCreated() {
+		string source = RandomFolder();
+		string destination = $"{RandomFolder()}/nested/target";
+
+		await CreateText($"{source}/a.txt", "one");
+
+		try {
+			await _storage.MoveDirectory(source, destination);
+		}
+		catch (NotImplementedException) {
+			return;
+		}
+
+		Assert.Equal("one", await _storage.GetText($"{destination}/a.txt"));
+	}
+
+}

--- a/FluentStorage/Storage/DiskStore.cs
+++ b/FluentStorage/Storage/DiskStore.cs
@@ -123,7 +123,10 @@ internal class DiskStore : StoreBase {
 		return _fileSystem.Path.Combine(dir, name);
 	}
 
-	private string NormalizeFolderPath(string path, bool createIfNotExists) {
+	/// <summary>
+	/// Resolves a storage folder path to a native path without requiring it to exist.
+	/// </summary>
+	private string GetFullFolderPath(string path) {
 		if (path == null) return _directoryFullName;
 		string[] parts = StoragePath.Split(path);
 
@@ -132,6 +135,14 @@ internal class DiskStore : StoreBase {
 		foreach (string part in parts) {
 			fullPath = _fileSystem.Path.Combine(fullPath, part);
 		}
+
+		return fullPath;
+	}
+
+	private string NormalizeFolderPath(string path, bool createIfNotExists) {
+		if (path == null) return _directoryFullName;
+
+		string fullPath = GetFullFolderPath(path);
 
 		if (!_fileSystem.Directory.Exists(fullPath)) {
 			if (createIfNotExists) {
@@ -533,15 +544,25 @@ internal class DiskStore : StoreBase {
 	/// </summary>
 	public override async Task MoveDirectory(string sourceFolderPath, string destinationFolderPath, CancellationToken cancellationToken = default) {
 		if (sourceFolderPath == null) throw new ArgumentNullException(nameof(sourceFolderPath));
-		if (destinationFolderPath == null) throw new ArgumentNullException(nameof(sourceFolderPath));
+		if (destinationFolderPath == null) throw new ArgumentNullException(nameof(destinationFolderPath));
 
 		sourceFolderPath = StoragePath.Normalize(sourceFolderPath);
 		destinationFolderPath = StoragePath.Normalize(destinationFolderPath);
 
 		string sourcePath = NormalizeFolderPath(sourceFolderPath, false);
-		string destinationPath = NormalizeFolderPath(destinationFolderPath, false);
+
+		// the destination of a move does not exist yet, so it must not be resolved through NormalizeFolderPath
+		string destinationPath = GetFullFolderPath(destinationFolderPath);
 
 		if (_fileSystem.Directory.Exists(sourcePath)) {
+
+			// Directory.Move does not create the parent of the destination
+			string destinationParent = _fileSystem.Path.GetDirectoryName(destinationPath);
+
+			if (!string.IsNullOrEmpty(destinationParent) && !_fileSystem.Directory.Exists(destinationParent)) {
+				_fileSystem.Directory.CreateDirectory(destinationParent);
+			}
+
 			_fileSystem.Directory.Move(sourcePath, destinationPath);
 		}
 


### PR DESCRIPTION
## Cause

`DiskStore.MoveDirectory` resolves both paths through `NormalizeFolderPath(path, createIfNotExists: false)`:

    string sourcePath = NormalizeFolderPath(sourceFolderPath, false);
    string destinationPath = NormalizeFolderPath(destinationFolderPath, false);

`NormalizeFolderPath` returns `null` when the folder does not exist and `createIfNotExists`
is false. The destination of a move does not exist yet by definition, so `destinationPath`
is always `null`, and that `null` goes straight into `Directory.Move`.

## Effect

`MoveDirectory` on `disk://` can never succeed. Every call throws:

    ArgumentNullException: Value cannot be null. (Parameter 'destDirName')

Reproduced with and without leading and trailing slashes. The same call works on
`inmemory://`, so the defect is specific to the disk provider.

Passing `createIfNotExists: true` would not be a fix either: it would create the
destination directory, and `Directory.Move` then fails because the destination exists.

A second, minor defect: the null check for `destinationFolderPath` reports the wrong
parameter name.

    if (destinationFolderPath == null) throw new ArgumentNullException(nameof(sourceFolderPath));

## Fix

Extract the segment-join loop from `NormalizeFolderPath` into a new helper,
`GetFullFolderPath`, which resolves a storage path to a native path **without** requiring
it to exist. `NormalizeFolderPath` now calls it and keeps its existing contract unchanged,
so `DeleteDirectory` and `ListObjects` continue to rely on `null` meaning "does not exist".

`MoveDirectory` resolves the destination with the new helper, and creates the destination's
**parent** if missing — `Directory.Move` does not create it. The parameter name in the
second null check is corrected to `nameof(destinationFolderPath)`.

All filesystem access goes through the injected `_fileSystem` (`System.IO.Abstractions`);
no direct `System.IO` calls were introduced.

## Semantics when the destination already exists

**Chosen: the destination must not already exist. If it does, the underlying
`Directory.Move` throws `IOException`.**

`MoveDirectory` is currently inconsistent across providers, and there is no single
behaviour that matches all of them:

| Provider | Primitive | Destination already exists |
|---|---|---|
| Disk | `Directory.Move` | throws `IOException` (this PR) |
| Git | `Directory.Move` | throws `IOException` |
| SFTP | `RenameFileAsync` | throws (server-dependent) |
| FTP | `MoveDirectory(…, FtpRemoteExists.Overwrite)` | overwrites |
| Memory | dictionary re-key | merges, overwriting colliding files |

The disk provider is aligned with `GitStore`, which is structurally identical — same
`Directory.Move`, same `if (Directory.Exists(source))` guard — and is evidently the code
`DiskStore.MoveDirectory` was modelled on.

Matching `MemoryStore` instead would require implementing recursive merge-and-overwrite
semantics on disk. That is a feature decision rather than a defect fix, and silently
overwriting existing files on a real filesystem deserves an explicit decision, so it is
deliberately out of scope here. Happy to follow up separately if maintainers prefer the
merge semantics — the cross-provider inconsistency is pre-existing and worth settling.

Two existing behaviours are preserved: a move whose **source** does not exist is a silent
no-op (matching `GitStore`), and `MoveDirectory` still returns a completed task.

## Tests

New `IStoreTest.DirMove.cs` in the shared provider suite, following the existing `Dir*`
file convention:

- `MoveDirectory_WithContent_MovesFilesToDestination` — nested content arrives at the
  destination and is gone from the source
- `MoveDirectory_EmptyFolder_DestinationExists` — an empty directory moves and the
  destination exists afterwards
- `MoveDirectory_DestinationParentDoesNotExist_IsCreated` — the destination is one level
  deeper than an existing directory, so the parent must be created

`StoreBase.MoveDirectory` throws `NotImplementedException`, so each test skips on providers
that do not implement it, using the same skip idiom the suite already applies to
`NotSupportedException`. Assertions are kept narrow enough to hold on `MemoryStore` as well.

Against the unfixed code all three fail with
`ArgumentNullException: Value cannot be null. (Parameter 'destDirName')`.

## Verification

- Solution builds with 0 errors.
- **LocalDisk suite: 219/219 pass** — the provider this PR fixes, no regressions.
- Memory suite: 215/219; the 4 failures are pre-existing and unaffected by this change.
- Unit suite: 607/609; the 2 `LocalDiskMessagingTest` failures are pre-existing and flaky.

The disk provider needs no external infrastructure, so the fixed code path is covered by
tests that actually ran.
